### PR TITLE
Add trace summary and span totals support

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -55,7 +55,7 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 					log.Printf("ingest: upsert span: %v", err)
 					continue
 				}
-				if err := h.notifier.PublishSpanEvent(ctx, row.TraceID, isNew); err != nil {
+				if err := h.notifier.PublishSpanEvent(ctx, row.TraceID, row.SpanID, isNew); err != nil {
 					log.Printf("ingest: publish span event: %v", err)
 				}
 			}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -24,14 +24,16 @@ func New(client notificationsv1.NotificationsServiceClient) *Notifier {
 	return &Notifier{client: client}
 }
 
-func (n *Notifier) PublishSpanEvent(ctx context.Context, traceID []byte, isNew bool) error {
+func (n *Notifier) PublishSpanEvent(ctx context.Context, traceID, spanID []byte, isNew bool) error {
 	event := spanUpdatedEvent
 	if isNew {
 		event = spanCreatedEvent
 	}
 	traceHex := hex.EncodeToString(traceID)
+	spanHex := hex.EncodeToString(spanID)
 	payload, err := structpb.NewStruct(map[string]any{
 		"trace_id": traceHex,
+		"span_id":  spanHex,
 	})
 	if err != nil {
 		return fmt.Errorf("build payload: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -102,6 +102,82 @@ func (s *Server) GetTrace(ctx context.Context, req *tracingv1.GetTraceRequest) (
 	return &tracingv1.GetTraceResponse{ResourceSpans: resourceSpans}, nil
 }
 
+func (s *Server) GetTraceSummary(ctx context.Context, req *tracingv1.GetTraceSummaryRequest) (*tracingv1.GetTraceSummaryResponse, error) {
+	if err := validateTraceID(req.GetTraceId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "trace_id: %v", err)
+	}
+	summary, err := s.store.GetTraceSummary(ctx, req.GetTraceId())
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	countsByName := make(map[string]int64, len(summary.Rows))
+	var (
+		runningCount int64
+		okCount      int64
+		errorCount   int64
+	)
+	for _, row := range summary.Rows {
+		countsByName[row.Name] = row.NameCount
+		runningCount += row.RunningCount
+		okCount += row.OkCount
+		errorCount += row.ErrorCount
+	}
+	countsByStatus := map[string]int64{
+		tracingv1.SpanStatus_SPAN_STATUS_RUNNING.String(): runningCount,
+		tracingv1.SpanStatus_SPAN_STATUS_OK.String():      okCount,
+		tracingv1.SpanStatus_SPAN_STATUS_ERROR.String():   errorCount,
+	}
+	traceStatus := tracingv1.TraceStatus_TRACE_STATUS_COMPLETED
+	if runningCount > 0 {
+		traceStatus = tracingv1.TraceStatus_TRACE_STATUS_RUNNING
+	} else if errorCount > 0 {
+		traceStatus = tracingv1.TraceStatus_TRACE_STATUS_ERROR
+	}
+	return &tracingv1.GetTraceSummaryResponse{
+		TraceId:            summary.TraceID,
+		Status:             traceStatus,
+		FirstSpanStartTime: uint64(summary.FirstSpanStartTime),
+		LastSpanStartTime:  uint64(summary.LastSpanStartTime),
+		LastSpanEndTime:    uint64(summary.LastSpanEndTime),
+		CountsByName:       countsByName,
+		CountsByStatus:     countsByStatus,
+		TotalSpans:         summary.TotalSpans,
+	}, nil
+}
+
+func (s *Server) GetTraceSpanTotals(ctx context.Context, req *tracingv1.GetTraceSpanTotalsRequest) (*tracingv1.GetTraceSpanTotalsResponse, error) {
+	if err := validateTraceID(req.GetTraceId()); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "trace_id: %v", err)
+	}
+	filter := store.TraceSpanTotalsFilter{
+		TraceID: req.GetTraceId(),
+	}
+	if len(req.GetNames()) > 0 {
+		filter.Names = req.GetNames()
+	}
+	if len(req.GetStatuses()) > 0 {
+		statuses, err := mapSpanStatuses(req.GetStatuses())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "statuses: %v", err)
+		}
+		filter.Statuses = statuses
+	}
+	result, err := s.store.GetTraceSpanTotals(ctx, filter)
+	if err != nil {
+		return nil, toStatusError(err)
+	}
+	return &tracingv1.GetTraceSpanTotalsResponse{
+		SpanCount: result.SpanCount,
+		TokenUsage: &tracingv1.TokenUsageTotals{
+			InputTokens:          result.InputTokens,
+			OutputTokens:         result.OutputTokens,
+			CacheReadInputTokens: result.CacheReadInputTokens,
+			ReasoningTokens:      result.ReasoningTokens,
+			TotalTokens:          result.InputTokens + result.OutputTokens,
+		},
+	}, nil
+}
+
 func parseSpanFilter(filter *tracingv1.SpanFilter) (store.SpanFilter, error) {
 	if filter == nil {
 		return store.SpanFilter{}, nil
@@ -119,7 +195,9 @@ func parseSpanFilter(filter *tracingv1.SpanFilter) (store.SpanFilter, error) {
 		}
 		result.ParentSpanID = filter.GetParentSpanId()
 	}
-	if filter.GetName() != "" {
+	if len(filter.GetNames()) > 0 {
+		result.Names = filter.GetNames()
+	} else if filter.GetName() != "" {
 		result.Name = filter.GetName()
 	}
 	if filter.GetKind() != 0 {
@@ -137,11 +215,44 @@ func parseSpanFilter(filter *tracingv1.SpanFilter) (store.SpanFilter, error) {
 		}
 		result.StartTimeMax = int64(filter.GetStartTimeMax())
 	}
-	if filter.InProgress != nil {
+	if len(filter.GetStatuses()) > 0 {
+		statuses, err := mapSpanStatuses(filter.GetStatuses())
+		if err != nil {
+			return store.SpanFilter{}, fmt.Errorf("statuses: %w", err)
+		}
+		result.Statuses = statuses
+	} else if filter.InProgress != nil {
 		value := filter.GetInProgress()
 		result.InProgress = &value
 	}
 	return result, nil
+}
+
+func mapSpanStatuses(statuses []tracingv1.SpanStatus) ([]store.SpanStatus, error) {
+	values := make([]store.SpanStatus, 0, len(statuses))
+	for _, statusValue := range statuses {
+		status, err := spanStatusFromProto(statusValue)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, status)
+	}
+	return values, nil
+}
+
+func spanStatusFromProto(status tracingv1.SpanStatus) (store.SpanStatus, error) {
+	switch status {
+	case tracingv1.SpanStatus_SPAN_STATUS_RUNNING:
+		return store.SpanStatusRunning, nil
+	case tracingv1.SpanStatus_SPAN_STATUS_OK:
+		return store.SpanStatusOk, nil
+	case tracingv1.SpanStatus_SPAN_STATUS_ERROR:
+		return store.SpanStatusError, nil
+	case tracingv1.SpanStatus_SPAN_STATUS_UNSPECIFIED:
+		return 0, fmt.Errorf("status is unspecified")
+	default:
+		return 0, fmt.Errorf("invalid status: %d", status)
+	}
 }
 
 func orderByFromProto(orderBy tracingv1.ListSpansOrderBy) (store.OrderBy, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -12,6 +12,8 @@ import (
 
 const spanColumns = "trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time_unix_nano, end_time_unix_nano, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, resource, instrumentation_scope"
 
+const spanStatusCaseExpr = "CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 2 WHEN status_code = 2 THEN 3 END"
+
 type Store struct {
 	pool *pgxpool.Pool
 }
@@ -128,6 +130,140 @@ func (s *Store) GetTrace(ctx context.Context, traceID []byte) ([]SpanRow, error)
 	return spans, nil
 }
 
+func (s *Store) GetTraceSummary(ctx context.Context, traceID []byte) (TraceSummary, error) {
+	query := `SELECT
+		name,
+		count(*) AS name_count,
+		min(start_time_unix_nano) AS first_start,
+		max(start_time_unix_nano) AS last_start,
+		max(end_time_unix_nano) AS last_end,
+		sum(CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 ELSE 0 END) AS running_count,
+		sum(CASE WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 1 ELSE 0 END) AS ok_count,
+		sum(CASE WHEN status_code = 2 THEN 1 ELSE 0 END) AS error_count
+	FROM spans
+	WHERE trace_id = $1
+	GROUP BY name`
+	rows, err := s.pool.Query(ctx, query, traceID)
+	if err != nil {
+		return TraceSummary{}, err
+	}
+	defer rows.Close()
+
+	summary := TraceSummary{TraceID: traceID}
+	initialized := false
+	for rows.Next() {
+		var (
+			name         string
+			nameCount    int64
+			firstStart   int64
+			lastStart    int64
+			lastEnd      int64
+			runningCount int64
+			okCount      int64
+			errorCount   int64
+		)
+		if err := rows.Scan(
+			&name,
+			&nameCount,
+			&firstStart,
+			&lastStart,
+			&lastEnd,
+			&runningCount,
+			&okCount,
+			&errorCount,
+		); err != nil {
+			return TraceSummary{}, err
+		}
+		summary.Rows = append(summary.Rows, TraceSummaryRow{
+			Name:         name,
+			NameCount:    nameCount,
+			RunningCount: runningCount,
+			OkCount:      okCount,
+			ErrorCount:   errorCount,
+		})
+		summary.TotalSpans += nameCount
+		if !initialized {
+			summary.FirstSpanStartTime = firstStart
+			summary.LastSpanStartTime = lastStart
+			summary.LastSpanEndTime = lastEnd
+			initialized = true
+			continue
+		}
+		if firstStart < summary.FirstSpanStartTime {
+			summary.FirstSpanStartTime = firstStart
+		}
+		if lastStart > summary.LastSpanStartTime {
+			summary.LastSpanStartTime = lastStart
+		}
+		if lastEnd > summary.LastSpanEndTime {
+			summary.LastSpanEndTime = lastEnd
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return TraceSummary{}, err
+	}
+	if !initialized {
+		return TraceSummary{}, ErrTraceNotFound
+	}
+	return summary, nil
+}
+
+func (s *Store) GetTraceSpanTotals(ctx context.Context, filter TraceSpanTotalsFilter) (TraceSpanTotals, error) {
+	query := strings.Builder{}
+	query.WriteString(`SELECT
+		count(*) AS span_count,
+		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			FROM jsonb_array_elements(attributes) AS elem
+			WHERE elem->>'key' = 'gen_ai.usage.input_tokens' LIMIT 1), 0)) AS input_tokens,
+		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			FROM jsonb_array_elements(attributes) AS elem
+			WHERE elem->>'key' = 'gen_ai.usage.output_tokens' LIMIT 1), 0)) AS output_tokens,
+		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			FROM jsonb_array_elements(attributes) AS elem
+			WHERE elem->>'key' = 'gen_ai.usage.cache_read.input_tokens' LIMIT 1), 0)) AS cache_read_input_tokens,
+		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			FROM jsonb_array_elements(attributes) AS elem
+			WHERE elem->>'key' = 'agyn.usage.reasoning_tokens' LIMIT 1), 0)) AS reasoning_tokens
+	FROM spans`)
+
+	args := []any{}
+	conditions := []string{}
+	paramIndex := 1
+
+	conditions = append(conditions, fmt.Sprintf("trace_id = $%d", paramIndex))
+	args = append(args, filter.TraceID)
+	paramIndex++
+
+	if len(filter.Names) > 0 {
+		conditions = append(conditions, fmt.Sprintf("name = ANY($%d)", paramIndex))
+		args = append(args, filter.Names)
+		paramIndex++
+	}
+	if len(filter.Statuses) > 0 {
+		statusValues := spanStatusValues(filter.Statuses)
+		conditions = append(conditions, fmt.Sprintf("(%s) = ANY($%d)", spanStatusCaseExpr, paramIndex))
+		args = append(args, statusValues)
+		paramIndex++
+	}
+
+	if len(conditions) > 0 {
+		query.WriteString(" WHERE ")
+		query.WriteString(strings.Join(conditions, " AND "))
+	}
+
+	var totals TraceSpanTotals
+	if err := s.pool.QueryRow(ctx, query.String(), args...).Scan(
+		&totals.SpanCount,
+		&totals.InputTokens,
+		&totals.OutputTokens,
+		&totals.CacheReadInputTokens,
+		&totals.ReasoningTokens,
+	); err != nil {
+		return TraceSpanTotals{}, err
+	}
+	return totals, nil
+}
+
 func (s *Store) ListSpans(ctx context.Context, filter SpanFilter, pageSize int32, cursor *SpanCursor, orderBy OrderBy) (SpanListResult, error) {
 	limit := normalizePageSize(pageSize)
 	orderBy = normalizeOrderBy(orderBy)
@@ -151,7 +287,11 @@ func (s *Store) ListSpans(ctx context.Context, filter SpanFilter, pageSize int32
 		args = append(args, filter.ParentSpanID)
 		paramIndex++
 	}
-	if filter.Name != "" {
+	if len(filter.Names) > 0 {
+		conditions = append(conditions, fmt.Sprintf("name = ANY($%d)", paramIndex))
+		args = append(args, filter.Names)
+		paramIndex++
+	} else if filter.Name != "" {
 		conditions = append(conditions, fmt.Sprintf("name = $%d", paramIndex))
 		args = append(args, filter.Name)
 		paramIndex++
@@ -171,7 +311,12 @@ func (s *Store) ListSpans(ctx context.Context, filter SpanFilter, pageSize int32
 		args = append(args, filter.StartTimeMax)
 		paramIndex++
 	}
-	if filter.InProgress != nil {
+	if len(filter.Statuses) > 0 {
+		statusValues := spanStatusValues(filter.Statuses)
+		conditions = append(conditions, fmt.Sprintf("(%s) = ANY($%d)", spanStatusCaseExpr, paramIndex))
+		args = append(args, statusValues)
+		paramIndex++
+	} else if filter.InProgress != nil {
 		if *filter.InProgress {
 			conditions = append(conditions, "end_time_unix_nano = 0")
 		} else {
@@ -272,4 +417,12 @@ func nullableJSONText(data []byte) any {
 		return nil
 	}
 	return string(data)
+}
+
+func spanStatusValues(statuses []SpanStatus) []int16 {
+	values := make([]int16, len(statuses))
+	for i, status := range statuses {
+		values[i] = int16(status)
+	}
+	return values
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -212,43 +212,34 @@ func (s *Store) GetTraceSpanTotals(ctx context.Context, filter TraceSpanTotalsFi
 	query := strings.Builder{}
 	query.WriteString(`SELECT
 		count(*) AS span_count,
-		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+		COALESCE(sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
 			FROM jsonb_array_elements(attributes) AS elem
-			WHERE elem->>'key' = 'gen_ai.usage.input_tokens' LIMIT 1), 0)) AS input_tokens,
-		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			WHERE elem->>'key' = 'gen_ai.usage.input_tokens' LIMIT 1), 0)), 0) AS input_tokens,
+		COALESCE(sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
 			FROM jsonb_array_elements(attributes) AS elem
-			WHERE elem->>'key' = 'gen_ai.usage.output_tokens' LIMIT 1), 0)) AS output_tokens,
-		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			WHERE elem->>'key' = 'gen_ai.usage.output_tokens' LIMIT 1), 0)), 0) AS output_tokens,
+		COALESCE(sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
 			FROM jsonb_array_elements(attributes) AS elem
-			WHERE elem->>'key' = 'gen_ai.usage.cache_read.input_tokens' LIMIT 1), 0)) AS cache_read_input_tokens,
-		sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
+			WHERE elem->>'key' = 'gen_ai.usage.cache_read.input_tokens' LIMIT 1), 0)), 0) AS cache_read_input_tokens,
+		COALESCE(sum(COALESCE((SELECT (elem->'value'->>'intValue')::BIGINT
 			FROM jsonb_array_elements(attributes) AS elem
-			WHERE elem->>'key' = 'agyn.usage.reasoning_tokens' LIMIT 1), 0)) AS reasoning_tokens
-	FROM spans`)
+			WHERE elem->>'key' = 'agyn.usage.reasoning_tokens' LIMIT 1), 0)), 0) AS reasoning_tokens
+	FROM spans
+	WHERE trace_id = $1`)
 
-	args := []any{}
-	conditions := []string{}
-	paramIndex := 1
-
-	conditions = append(conditions, fmt.Sprintf("trace_id = $%d", paramIndex))
-	args = append(args, filter.TraceID)
-	paramIndex++
+	args := []any{filter.TraceID}
+	paramIndex := 2
 
 	if len(filter.Names) > 0 {
-		conditions = append(conditions, fmt.Sprintf("name = ANY($%d)", paramIndex))
+		query.WriteString(fmt.Sprintf(" AND name = ANY($%d)", paramIndex))
 		args = append(args, filter.Names)
 		paramIndex++
 	}
 	if len(filter.Statuses) > 0 {
 		statusValues := spanStatusValues(filter.Statuses)
-		conditions = append(conditions, fmt.Sprintf("(%s) = ANY($%d)", spanStatusCaseExpr, paramIndex))
+		query.WriteString(fmt.Sprintf(" AND (%s) = ANY($%d)", spanStatusCaseExpr, paramIndex))
 		args = append(args, statusValues)
 		paramIndex++
-	}
-
-	if len(conditions) > 0 {
-		query.WriteString(" WHERE ")
-		query.WriteString(strings.Join(conditions, " AND "))
 	}
 
 	var totals TraceSpanTotals

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -7,6 +7,14 @@ var (
 	ErrTraceNotFound = errors.New("trace not found")
 )
 
+type SpanStatus int16
+
+const (
+	SpanStatusRunning SpanStatus = 1 // end_time = 0, status_code != 2 (ERROR)
+	SpanStatusOk      SpanStatus = 2 // end_time > 0, status_code != 2
+	SpanStatusError   SpanStatus = 3 // status_code = 2
+)
+
 type SpanRow struct {
 	TraceID                []byte
 	SpanID                 []byte
@@ -33,10 +41,43 @@ type SpanFilter struct {
 	TraceID      []byte
 	ParentSpanID []byte
 	Name         string
+	Names        []string
 	Kind         int16
 	StartTimeMin int64
 	StartTimeMax int64
 	InProgress   *bool
+	Statuses     []SpanStatus
+}
+
+type TraceSummary struct {
+	TraceID            []byte
+	TotalSpans         int64
+	FirstSpanStartTime int64
+	LastSpanStartTime  int64
+	LastSpanEndTime    int64
+	Rows               []TraceSummaryRow
+}
+
+type TraceSummaryRow struct {
+	Name         string
+	NameCount    int64
+	RunningCount int64
+	OkCount      int64
+	ErrorCount   int64
+}
+
+type TraceSpanTotalsFilter struct {
+	TraceID  []byte
+	Names    []string
+	Statuses []SpanStatus
+}
+
+type TraceSpanTotals struct {
+	SpanCount            int64
+	InputTokens          int64
+	OutputTokens         int64
+	CacheReadInputTokens int64
+	ReasoningTokens      int64
 }
 
 type SpanCursor struct {


### PR DESCRIPTION
## Summary
- add store types and queries for trace summary and span totals
- implement new tracing RPCs and filter parsing
- enrich span notifications with span_id

## Testing
- buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1
- go vet ./...
- go test ./...
- go build ./...

Closes #4