### PR TITLE
fix(ingest): normalize root parent span

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -136,12 +136,16 @@ func spanToRow(span *tracev1.Span, resourceData, scopeData []byte) (store.SpanRo
 		}
 		statusMessage = status.GetMessage()
 	}
+	parentSpanID := span.GetParentSpanId()
+	if parentSpanID == nil {
+		parentSpanID = []byte{}
+	}
 
 	return store.SpanRow{
 		TraceID:                span.GetTraceId(),
 		SpanID:                 span.GetSpanId(),
 		TraceState:             span.GetTraceState(),
-		ParentSpanID:           span.GetParentSpanId(),
+		ParentSpanID:           parentSpanID,
 		Flags:                  flags,
 		Name:                   span.GetName(),
 		Kind:                   kind,

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,0 +1,23 @@
+package ingest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+func TestSpanToRowNormalizesParentSpanID(t *testing.T) {
+	span := &tracev1.Span{
+		TraceId:           []byte{0x01},
+		SpanId:            []byte{0x02},
+		ParentSpanId:      nil,
+		StartTimeUnixNano: 1,
+		EndTimeUnixNano:   2,
+	}
+
+	row, err := spanToRow(span, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, row.ParentSpanID)
+	require.Len(t, row.ParentSpanID, 0)
+}


### PR DESCRIPTION
## Summary
- normalize nil parent span IDs to empty bytes before insert
- add ingest test covering root-span parent normalization

## Testing
- buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1
- go test ./...
- go vet ./...

Closes #8