### PR TITLE
feat(tracing): enforce list span filters

### DIFF
--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 6e170d31244342e1b94ea333fd898c93
-    digest: shake256:8003674442ebdd9c447df6ca1b1a54ff678026264d29d9368413aeda2493740695f5bf4ee71a638afd54b226bfeece4585bb1a6e249374735b43d87a4c32cf5f
+    commit: 59e938f9b92c433e9cf5480b3dd62a3a
+    digest: shake256:95f72447b92fba73722d9a2e060bc32e0f0e639f81282249a32b9d07a7511e81f1247eda7d5f64a9a015481bfddc8e247784b0c96dc69c8f1c646795b6eba09d
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -28,10 +28,14 @@ func New(store *store.Store) *Server {
 }
 
 func (s *Server) ListSpans(ctx context.Context, req *tracingv1.ListSpansRequest) (*tracingv1.ListSpansResponse, error) {
+	if req.GetOrganizationId() == "" {
+		return nil, status.Error(codes.InvalidArgument, "organization_id is required")
+	}
 	filter, err := parseSpanFilter(req.GetFilter())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "filter: %v", err)
 	}
+	filter.OrganizationID = req.GetOrganizationId()
 	orderBy, err := orderByFromProto(req.GetOrderBy())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "order_by: %v", err)
@@ -224,6 +228,9 @@ func parseSpanFilter(filter *tracingv1.SpanFilter) (store.SpanFilter, error) {
 	} else if filter.InProgress != nil {
 		value := filter.GetInProgress()
 		result.InProgress = &value
+	}
+	if filter.GetMessageId() != "" {
+		result.MessageID = filter.GetMessageId()
 	}
 	return result, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	tracingv1 "github.com/agynio/tracing/.gen/go/agynio/api/tracing/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestListSpansRequiresOrganizationID(t *testing.T) {
+	server := New(nil)
+	_, err := server.ListSpans(context.Background(), &tracingv1.ListSpansRequest{})
+	require.Error(t, err)
+
+	statusErr, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, statusErr.Code())
+	assert.Contains(t, statusErr.Message(), "organization_id")
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -10,9 +10,11 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const spanColumns = "trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time_unix_nano, end_time_unix_nano, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, resource, instrumentation_scope"
-
-const spanStatusCaseExpr = "CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 2 WHEN status_code = 2 THEN 3 END"
+const (
+	spanColumns                = "trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time_unix_nano, end_time_unix_nano, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, resource, instrumentation_scope"
+	spanStatusCaseExpr         = "CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 2 WHEN status_code = 2 THEN 3 END"
+	resourceAttrOrganizationID = "agyn.organization.id"
+)
 
 type Store struct {
 	pool *pgxpool.Pool
@@ -268,9 +270,18 @@ func (s *Store) ListSpans(ctx context.Context, filter SpanFilter, pageSize int32
 	conditions := []string{}
 	paramIndex := 1
 
+	conditions = append(conditions, fmt.Sprintf("%s = $%d", resourceAttributeValueExpr(resourceAttrOrganizationID), paramIndex))
+	args = append(args, filter.OrganizationID)
+	paramIndex++
+
 	if len(filter.TraceID) > 0 {
 		conditions = append(conditions, fmt.Sprintf("trace_id = $%d", paramIndex))
 		args = append(args, filter.TraceID)
+		paramIndex++
+	}
+	if filter.MessageID != "" {
+		conditions = append(conditions, fmt.Sprintf("message_id = $%d", paramIndex))
+		args = append(args, filter.MessageID)
 		paramIndex++
 	}
 	if len(filter.ParentSpanID) > 0 {
@@ -408,6 +419,10 @@ func nullableJSONText(data []byte) any {
 		return nil
 	}
 	return string(data)
+}
+
+func resourceAttributeValueExpr(attribute string) string {
+	return fmt.Sprintf("(jsonb_path_query_first(COALESCE(resource, '{}'::jsonb), '$.attributes[*] ? (@.key == \"%s\").value.stringValue') #>> '{}')", attribute)
 }
 
 func spanStatusValues(statuses []SpanStatus) []int16 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,9 +11,8 @@ import (
 )
 
 const (
-	spanColumns                = "trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time_unix_nano, end_time_unix_nano, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, resource, instrumentation_scope"
-	spanStatusCaseExpr         = "CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 2 WHEN status_code = 2 THEN 3 END"
-	resourceAttrOrganizationID = "agyn.organization.id"
+	spanColumns        = "trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time_unix_nano, end_time_unix_nano, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, resource, instrumentation_scope"
+	spanStatusCaseExpr = "CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 2 WHEN status_code = 2 THEN 3 END"
 )
 
 type Store struct {
@@ -270,7 +269,7 @@ func (s *Store) ListSpans(ctx context.Context, filter SpanFilter, pageSize int32
 	conditions := []string{}
 	paramIndex := 1
 
-	conditions = append(conditions, fmt.Sprintf("%s = $%d", resourceAttributeValueExpr(resourceAttrOrganizationID), paramIndex))
+	conditions = append(conditions, fmt.Sprintf("organization_id = $%d", paramIndex))
 	args = append(args, filter.OrganizationID)
 	paramIndex++
 
@@ -419,10 +418,6 @@ func nullableJSONText(data []byte) any {
 		return nil
 	}
 	return string(data)
-}
-
-func resourceAttributeValueExpr(attribute string) string {
-	return fmt.Sprintf("(jsonb_path_query_first(COALESCE(resource, '{}'::jsonb), '$.attributes[*] ? (@.key == \"%s\").value.stringValue') #>> '{}')", attribute)
 }
 
 func spanStatusValues(statuses []SpanStatus) []int16 {

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -38,15 +38,17 @@ type SpanRow struct {
 }
 
 type SpanFilter struct {
-	TraceID      []byte
-	ParentSpanID []byte
-	Name         string
-	Names        []string
-	Kind         int16
-	StartTimeMin int64
-	StartTimeMax int64
-	InProgress   *bool
-	Statuses     []SpanStatus
+	OrganizationID string
+	TraceID        []byte
+	ParentSpanID   []byte
+	Name           string
+	Names          []string
+	Kind           int16
+	StartTimeMin   int64
+	StartTimeMax   int64
+	InProgress     *bool
+	Statuses       []SpanStatus
+	MessageID      string
 }
 
 type TraceSummary struct {

--- a/migrations/0002_message_id_index.sql
+++ b/migrations/0002_message_id_index.sql
@@ -1,0 +1,9 @@
+ALTER TABLE spans
+    ADD COLUMN message_id TEXT GENERATED ALWAYS AS (
+        jsonb_path_query_first(
+            COALESCE(resource, '{}'::jsonb),
+            '$.attributes[*] ? (@.key == "agyn.thread.message.id").value.stringValue'
+        ) #>> '{}'
+    ) STORED;
+
+CREATE INDEX idx_spans_message_id ON spans (message_id) WHERE message_id IS NOT NULL;

--- a/migrations/0003_organization_id_index.sql
+++ b/migrations/0003_organization_id_index.sql
@@ -1,0 +1,9 @@
+ALTER TABLE spans
+    ADD COLUMN organization_id TEXT GENERATED ALWAYS AS (
+        jsonb_path_query_first(
+            COALESCE(resource, '{}'::jsonb),
+            '$.attributes[*] ? (@.key == "agyn.organization.id").value.stringValue'
+        ) #>> '{}'
+    ) STORED;
+
+CREATE INDEX idx_spans_organization_id ON spans (organization_id) WHERE organization_id IS NOT NULL;

--- a/test/e2e/spans_test.go
+++ b/test/e2e/spans_test.go
@@ -22,6 +22,8 @@ const (
 	spanSummarization     = "summarization"
 
 	attrThreadID                   = "agyn.thread.id"
+	attrOrganizationID             = "agyn.organization.id"
+	attrMessageID                  = "agyn.thread.message.id"
 	attrMessageText                = "agyn.message.text"
 	attrMessageRole                = "agyn.message.role"
 	attrMessageKind                = "agyn.message.kind"
@@ -55,6 +57,11 @@ const (
 	defaultInvocationMessageRole   = "user"
 	defaultInvocationMessageKind   = "source"
 	defaultLLMToolCallResponseText = "Tool results"
+	defaultOrganizationID          = "11111111-1111-1111-1111-111111111111"
+	otherOrganizationID            = "22222222-2222-2222-2222-222222222222"
+	defaultMessageID               = "33333333-3333-3333-3333-333333333333"
+	otherMessageID                 = "44444444-4444-4444-4444-444444444444"
+	missingMessageID               = "55555555-5555-5555-5555-555555555555"
 )
 
 func TestIngestAndQuerySimpleTrace(t *testing.T) {
@@ -95,7 +102,8 @@ func TestIngestAndQuerySimpleTrace(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
-			Filter: &tracingv1.SpanFilter{TraceId: traceID},
+			OrganizationId: defaultOrganizationID,
+			Filter:         &tracingv1.SpanFilter{TraceId: traceID},
 		})
 		assert.NoError(c, err)
 		if err != nil {
@@ -241,6 +249,7 @@ func TestIngestToolExecutionSpan(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
 			Filter: &tracingv1.SpanFilter{
 				TraceId: traceID,
 				Names:   []string{spanToolExecution},
@@ -423,8 +432,9 @@ func TestMCPToolTrace(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
-			Filter:  &tracingv1.SpanFilter{TraceId: traceID},
-			OrderBy: tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_ASC,
+			OrganizationId: defaultOrganizationID,
+			Filter:         &tracingv1.SpanFilter{TraceId: traceID},
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_ASC,
 		})
 		assert.NoError(c, err)
 		if err != nil {
@@ -552,6 +562,7 @@ func TestUpsertInProgressSpan(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
 			Filter: &tracingv1.SpanFilter{
 				TraceId:  traceID,
 				Statuses: []tracingv1.SpanStatus{tracingv1.SpanStatus_SPAN_STATUS_RUNNING},
@@ -603,6 +614,7 @@ func TestUpsertInProgressSpan(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
 			Filter: &tracingv1.SpanFilter{
 				TraceId:  traceID,
 				Statuses: []tracingv1.SpanStatus{tracingv1.SpanStatus_SPAN_STATUS_OK},
@@ -672,6 +684,7 @@ func TestListSpansFiltering(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
 			Filter: &tracingv1.SpanFilter{
 				TraceId: traceID,
 				Names:   []string{spanLLMCall},
@@ -692,6 +705,7 @@ func TestListSpansFiltering(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
 			Filter: &tracingv1.SpanFilter{
 				TraceId:  traceID,
 				Statuses: []tracingv1.SpanStatus{tracingv1.SpanStatus_SPAN_STATUS_ERROR},
@@ -712,9 +726,10 @@ func TestListSpansFiltering(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancel()
 		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
-			Filter:   &tracingv1.SpanFilter{TraceId: traceID},
-			PageSize: 2,
-			OrderBy:  tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_ASC,
+			OrganizationId: defaultOrganizationID,
+			Filter:         &tracingv1.SpanFilter{TraceId: traceID},
+			PageSize:       2,
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_ASC,
 		})
 		assert.NoError(c, err)
 		if err != nil {
@@ -728,10 +743,11 @@ func TestListSpansFiltering(t *testing.T) {
 		ctxNext, cancelNext := context.WithTimeout(context.Background(), requestTimeout)
 		defer cancelNext()
 		secondResp, err := queryClient.ListSpans(ctxNext, &tracingv1.ListSpansRequest{
-			Filter:    &tracingv1.SpanFilter{TraceId: traceID},
-			PageSize:  2,
-			OrderBy:   tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_ASC,
-			PageToken: listResp.GetNextPageToken(),
+			OrganizationId: defaultOrganizationID,
+			Filter:         &tracingv1.SpanFilter{TraceId: traceID},
+			PageSize:       2,
+			OrderBy:        tracingv1.ListSpansOrderBy_LIST_SPANS_ORDER_BY_START_TIME_ASC,
+			PageToken:      listResp.GetNextPageToken(),
 		})
 		assert.NoError(c, err)
 		if err != nil {
@@ -742,6 +758,105 @@ func TestListSpansFiltering(t *testing.T) {
 			return
 		}
 		assert.Empty(c, secondResp.GetNextPageToken())
+	})
+}
+
+func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
+	traceID := newTraceID()
+	threadID := fmt.Sprintf("thread-%x", traceID)
+	startNs := uint64(time.Now().UnixNano())
+	orgSpan := buildSpan(
+		spanInvocationMessage,
+		traceID,
+		newSpanID(),
+		startNs,
+		startNs+1_000_000,
+		invocationMessageAttrs("Org scope"),
+	)
+	messageSpan := buildSpan(
+		spanLLMCall,
+		traceID,
+		newSpanID(),
+		startNs+2_000_000,
+		startNs+3_000_000,
+		llmCallAttrs("Message filter", 5, 2, 0, 0),
+	)
+	otherOrgSpan := buildSpan(
+		spanToolExecution,
+		traceID,
+		newSpanID(),
+		startNs+4_000_000,
+		startNs+5_000_000,
+		toolExecutionAttrs("org.tool", "{}", "ok", "call-org"),
+	)
+	resourceSpans := []*tracev1.ResourceSpans{
+		buildResourceSpans([]*tracev1.Span{orgSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, defaultMessageID)),
+		buildResourceSpans([]*tracev1.Span{messageSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, otherMessageID)),
+		buildResourceSpans([]*tracev1.Span{otherOrgSpan}, resourceAttrsWithMessageID(threadID, otherOrganizationID, defaultMessageID)),
+	}
+
+	collectorClient, queryClient := newTracingClients(t)
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	resp, err := exportSpans(ctx, collectorClient, resourceSpans)
+	require.NoError(t, err)
+	require.Equal(t, int64(0), resp.GetPartialSuccess().GetRejectedSpans())
+
+	requireEventually(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
+			Filter:         &tracingv1.SpanFilter{TraceId: traceID},
+		})
+		assert.NoError(c, err)
+		if err != nil {
+			return
+		}
+		spans := flattenSpans(listResp.GetResourceSpans())
+		if !assert.Len(c, spans, 2) {
+			return
+		}
+		assert.ElementsMatch(c, []string{spanInvocationMessage, spanLLMCall}, spanNames(spans))
+	})
+
+	requireEventually(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
+			Filter: &tracingv1.SpanFilter{
+				TraceId:   traceID,
+				MessageId: defaultMessageID,
+			},
+		})
+		assert.NoError(c, err)
+		if err != nil {
+			return
+		}
+		spans := flattenSpans(listResp.GetResourceSpans())
+		if !assert.Len(c, spans, 1) {
+			return
+		}
+		assert.Equal(c, spanInvocationMessage, spans[0].GetName())
+	})
+
+	requireEventually(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
+			Filter: &tracingv1.SpanFilter{
+				TraceId:   traceID,
+				MessageId: missingMessageID,
+			},
+		})
+		assert.NoError(c, err)
+		if err != nil {
+			return
+		}
+		spans := flattenSpans(listResp.GetResourceSpans())
+		assert.Empty(c, spans)
 	})
 }
 
@@ -847,7 +962,18 @@ func summarizationAttrs(text string, newContextCount, oldContextTokens int64) []
 }
 
 func resourceAttrs(threadID string) []*commonv1.KeyValue {
-	return []*commonv1.KeyValue{stringAttr(attrThreadID, threadID)}
+	return resourceAttrsWithMessageID(threadID, defaultOrganizationID, "")
+}
+
+func resourceAttrsWithMessageID(threadID, organizationID, messageID string) []*commonv1.KeyValue {
+	attrs := []*commonv1.KeyValue{
+		stringAttr(attrThreadID, threadID),
+		stringAttr(attrOrganizationID, organizationID),
+	}
+	if messageID != "" {
+		attrs = append(attrs, stringAttr(attrMessageID, messageID))
+	}
+	return attrs
 }
 
 func contextEvent(role, text string, isNew bool, sizeBytes int64, timestampNs uint64) *tracev1.Span_Event {


### PR DESCRIPTION
## Summary
- update api dependency lock and regenerate protobuf bindings
- enforce organization_id validation and filtering for ListSpans
- add message_id + organization_id generated columns with indexes
- update ListSpans filtering tests for org/message filtering and validation

## Commands + Results
- buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 (pass)
- go test ./... (pass)
- go vet ./... (pass)
- go build ./... (pass)

## Issue
Refs #13