### PR TITLE
feat(tracing): enrich span ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
 
       - name: Run tests
         run: go test ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           version: 1.66.0
 
       - name: Generate protobuf bindings
-        run: buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
+        run: buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1
 
       - name: Run tests
         run: go test ./...

--- a/cmd/tracing/main.go
+++ b/cmd/tracing/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/agynio/tracing/internal/notifier"
 	"github.com/agynio/tracing/internal/server"
 	"github.com/agynio/tracing/internal/store"
+	"github.com/agynio/tracing/internal/threadsclient"
 	"github.com/agynio/tracing/internal/ziticonn"
 	"github.com/agynio/tracing/internal/zitimanager"
 	"github.com/agynio/tracing/internal/zitimgmtclient"
@@ -78,6 +79,16 @@ func run() error {
 
 	st := store.NewStore(pool)
 	n := notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn))
+
+	threadsClient, err := threadsclient.NewClient(cfg.ThreadsAddress)
+	if err != nil {
+		return fmt.Errorf("create threads client: %w", err)
+	}
+	defer func() {
+		if closeErr := threadsClient.Close(); closeErr != nil {
+			log.Printf("failed to close threads client: %v", closeErr)
+		}
+	}()
 
 	var zitiMgmtClient *zitimgmtclient.Client
 	var agentsClient *agentsclient.Client
@@ -135,7 +146,7 @@ func run() error {
 
 	grpcServer := grpc.NewServer()
 	tracingv1.RegisterTracingServiceServer(grpcServer, server.New(st))
-	collectortracev1.RegisterTraceServiceServer(grpcServer, ingest.NewHandler(st, n, identityResolver, threadAuthorizer))
+	collectortracev1.RegisterTraceServiceServer(grpcServer, ingest.NewHandler(st, n, identityResolver, threadAuthorizer, threadsClient))
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {

--- a/cmd/tracing/main.go
+++ b/cmd/tracing/main.go
@@ -10,6 +10,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	notificationsv1 "github.com/agynio/tracing/.gen/go/agynio/api/notifications/v1"
 	tracingv1 "github.com/agynio/tracing/.gen/go/agynio/api/tracing/v1"
@@ -20,14 +21,24 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/agynio/tracing/internal/agentsclient"
+	"github.com/agynio/tracing/internal/authzclient"
+	"github.com/agynio/tracing/internal/cache"
 	"github.com/agynio/tracing/internal/config"
 	"github.com/agynio/tracing/internal/db"
+	"github.com/agynio/tracing/internal/identity"
 	"github.com/agynio/tracing/internal/ingest"
 	"github.com/agynio/tracing/internal/notifier"
 	"github.com/agynio/tracing/internal/server"
 	"github.com/agynio/tracing/internal/store"
+	"github.com/agynio/tracing/internal/ziticonn"
 	"github.com/agynio/tracing/internal/zitimanager"
 	"github.com/agynio/tracing/internal/zitimgmtclient"
+)
+
+const (
+	defaultIdentityCacheTTL = 5 * time.Minute
+	defaultThreadCacheTTL   = 5 * time.Minute
 )
 
 func main() {
@@ -68,14 +79,69 @@ func run() error {
 	st := store.NewStore(pool)
 	n := notifier.New(notificationsv1.NewNotificationsServiceClient(notificationsConn))
 
+	var zitiMgmtClient *zitimgmtclient.Client
+	var agentsClient *agentsclient.Client
+	var authzClient *authzclient.Client
+	var identityResolver *identity.Resolver
+	var threadAuthorizer *identity.ThreadAuthorizer
+	if cfg.ZitiEnabled {
+		zitiMgmtClient, err = zitimgmtclient.NewClient(cfg.ZitiManagementAddress)
+		if err != nil {
+			return fmt.Errorf("create ziti management client: %w", err)
+		}
+		defer func() {
+			if closeErr := zitiMgmtClient.Close(); closeErr != nil {
+				log.Printf("failed to close ziti management client: %v", closeErr)
+			}
+		}()
+
+		agentsClient, err = agentsclient.NewClient(cfg.AgentsServiceAddress)
+		if err != nil {
+			return fmt.Errorf("create agents client: %w", err)
+		}
+		defer func() {
+			if closeErr := agentsClient.Close(); closeErr != nil {
+				log.Printf("failed to close agents client: %v", closeErr)
+			}
+		}()
+
+		authzClient, err = authzclient.NewClient(cfg.AuthorizationAddress)
+		if err != nil {
+			return fmt.Errorf("create authorization client: %w", err)
+		}
+		defer func() {
+			if closeErr := authzClient.Close(); closeErr != nil {
+				log.Printf("failed to close authorization client: %v", closeErr)
+			}
+		}()
+
+		identityCache, err := cache.NewLRU[string, identity.IdentityChain](cfg.IdentityResolutionCache, defaultIdentityCacheTTL)
+		if err != nil {
+			return fmt.Errorf("create identity cache: %w", err)
+		}
+		threadCache, err := cache.NewLRU[string, bool](cfg.ThreadAuthorizationCache, defaultThreadCacheTTL)
+		if err != nil {
+			return fmt.Errorf("create thread cache: %w", err)
+		}
+		identityResolver, err = identity.NewResolver(zitiMgmtClient, agentsClient, identityCache)
+		if err != nil {
+			return fmt.Errorf("create identity resolver: %w", err)
+		}
+		threadAuthorizer, err = identity.NewThreadAuthorizer(authzClient, threadCache)
+		if err != nil {
+			return fmt.Errorf("create thread authorizer: %w", err)
+		}
+	}
+
 	grpcServer := grpc.NewServer()
 	tracingv1.RegisterTracingServiceServer(grpcServer, server.New(st))
-	collectortracev1.RegisterTraceServiceServer(grpcServer, ingest.NewHandler(st, n))
+	collectortracev1.RegisterTraceServiceServer(grpcServer, ingest.NewHandler(st, n, identityResolver, threadAuthorizer))
 
 	lis, err := net.Listen("tcp", cfg.GRPCAddress)
 	if err != nil {
 		return fmt.Errorf("listen on %s: %w", cfg.GRPCAddress, err)
 	}
+	lis = ziticonn.WrapListener(lis)
 
 	errCh := make(chan error, 2)
 
@@ -92,16 +158,6 @@ func run() error {
 	}()
 
 	if cfg.ZitiEnabled {
-		zitiMgmtClient, err := zitimgmtclient.NewClient(cfg.ZitiManagementAddress)
-		if err != nil {
-			return fmt.Errorf("create ziti management client: %w", err)
-		}
-		defer func() {
-			if closeErr := zitiMgmtClient.Close(); closeErr != nil {
-				log.Printf("failed to close ziti management client: %v", closeErr)
-			}
-		}()
-
 		var listenerMu sync.Mutex
 		var currentListener net.Listener
 		listenerFactory := func(zitiCtx ziti.Context) (net.Listener, error) {
@@ -113,12 +169,14 @@ func run() error {
 			currentListener = listener
 			listenerMu.Unlock()
 
+			wrappedListener := ziticonn.WrapListener(listener)
+
 			log.Printf("TracingService listening on ziti service %s", cfg.ZitiServiceName)
 			go func(activeListener net.Listener) {
 				if err := grpcServer.Serve(activeListener); err != nil && !errors.Is(err, grpc.ErrServerStopped) && !errors.Is(err, net.ErrClosed) {
 					errCh <- fmt.Errorf("ziti server stopped: %w", err)
 				}
-			}(listener)
+			}(wrappedListener)
 
 			if previousListener != nil {
 				if err := previousListener.Close(); err != nil {

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1
+                  buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
                   exec go run ./cmd/tracing
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=tracing-e2e" \
         -n ${TRACING_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -52,7 +52,7 @@ functions:
                     sleep 1; elapsed=$((elapsed + 1))
                     [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
                   done
-                  buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1
+                  buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1
                   exec go run ./cmd/tracing
               volumeMounts:
                 - name: data
@@ -135,7 +135,7 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=tracing-e2e" \
         -n ${TRACING_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/internal/agentsclient/client.go
+++ b/internal/agentsclient/client.go
@@ -1,0 +1,62 @@
+package agentsclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	agentsv1 "github.com/agynio/tracing/.gen/go/agynio/api/agents/v1"
+	"github.com/agynio/tracing/internal/identity"
+)
+
+type Client struct {
+	conn   *grpc.ClientConn
+	client agentsv1.AgentsServiceClient
+}
+
+func NewClient(target string) (*Client, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		conn:   conn,
+		client: agentsv1.NewAgentsServiceClient(conn),
+	}, nil
+}
+
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Client) ResolveAgentIdentity(ctx context.Context, identityID string) (identity.AgentIdentity, error) {
+	trimmed := strings.TrimSpace(identityID)
+	if trimmed == "" {
+		return identity.AgentIdentity{}, fmt.Errorf("identity id is required")
+	}
+
+	response, err := c.client.ResolveAgentIdentity(ctx, &agentsv1.ResolveAgentIdentityRequest{IdentityId: trimmed})
+	if err != nil {
+		return identity.AgentIdentity{}, err
+	}
+
+	agentID := strings.TrimSpace(response.GetAgentId())
+	if agentID == "" {
+		return identity.AgentIdentity{}, fmt.Errorf("agent id missing")
+	}
+
+	orgID := strings.TrimSpace(response.GetOrganizationId())
+	if orgID == "" {
+		return identity.AgentIdentity{}, fmt.Errorf("organization id missing")
+	}
+
+	return identity.AgentIdentity{AgentID: agentID, OrganizationID: orgID}, nil
+}

--- a/internal/authzclient/client.go
+++ b/internal/authzclient/client.go
@@ -1,0 +1,59 @@
+package authzclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	authorizationv1 "github.com/agynio/tracing/.gen/go/agynio/api/authorization/v1"
+)
+
+type Client struct {
+	conn   *grpc.ClientConn
+	client authorizationv1.AuthorizationServiceClient
+}
+
+func NewClient(target string) (*Client, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		conn:   conn,
+		client: authorizationv1.NewAuthorizationServiceClient(conn),
+	}, nil
+}
+
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Client) Check(ctx context.Context, user, relation, object string) (bool, error) {
+	user = strings.TrimSpace(user)
+	relation = strings.TrimSpace(relation)
+	object = strings.TrimSpace(object)
+	if user == "" || relation == "" || object == "" {
+		return false, fmt.Errorf("user, relation, and object are required")
+	}
+
+	response, err := c.client.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     user,
+			Relation: relation,
+			Object:   object,
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return response.GetAllowed(), nil
+}

--- a/internal/cache/lru.go
+++ b/internal/cache/lru.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"container/list"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type entry[K comparable, V any] struct {
+	key       K
+	value     V
+	expiresAt time.Time
+}
+
+type LRU[K comparable, V any] struct {
+	mu         sync.Mutex
+	maxEntries int
+	ttl        time.Duration
+	items      map[K]*list.Element
+	order      *list.List
+}
+
+func NewLRU[K comparable, V any](maxEntries int, ttl time.Duration) (*LRU[K, V], error) {
+	if maxEntries <= 0 {
+		return nil, fmt.Errorf("max entries must be positive")
+	}
+	if ttl <= 0 {
+		return nil, fmt.Errorf("ttl must be positive")
+	}
+	return &LRU[K, V]{
+		maxEntries: maxEntries,
+		ttl:        ttl,
+		items:      make(map[K]*list.Element, maxEntries),
+		order:      list.New(),
+	}, nil
+}
+
+func (l *LRU[K, V]) Get(key K) (V, bool) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	element, ok := l.items[key]
+	if !ok {
+		var zero V
+		return zero, false
+	}
+
+	entryValue := element.Value.(*entry[K, V])
+	if time.Now().After(entryValue.expiresAt) {
+		l.removeElement(element)
+		var zero V
+		return zero, false
+	}
+
+	l.order.MoveToFront(element)
+	return entryValue.value, true
+}
+
+func (l *LRU[K, V]) Add(key K, value V) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if element, ok := l.items[key]; ok {
+		entryValue := element.Value.(*entry[K, V])
+		entryValue.value = value
+		entryValue.expiresAt = time.Now().Add(l.ttl)
+		l.order.MoveToFront(element)
+		return
+	}
+
+	entryValue := &entry[K, V]{
+		key:       key,
+		value:     value,
+		expiresAt: time.Now().Add(l.ttl),
+	}
+	item := l.order.PushFront(entryValue)
+	l.items[key] = item
+
+	if l.order.Len() > l.maxEntries {
+		l.removeOldest()
+	}
+}
+
+func (l *LRU[K, V]) removeOldest() {
+	oldest := l.order.Back()
+	if oldest == nil {
+		return
+	}
+	l.removeElement(oldest)
+}
+
+func (l *LRU[K, V]) removeElement(element *list.Element) {
+	entryValue := element.Value.(*entry[K, V])
+	delete(l.items, entryValue.key)
+	l.order.Remove(element)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,10 @@ import (
 
 const (
 	defaultGRPCAddress        = ":50051"
+	defaultAgentsServiceAddr  = "agents:50051"
+	defaultAuthzServiceAddr   = "authorization:50051"
+	defaultIdentityCacheSize  = 1000
+	defaultThreadAuthCache    = 1000
 	defaultZitiManagementAddr = "ziti-management:50051"
 	defaultZitiServiceName    = "tracing"
 	defaultZitiLeaseInterval  = 2 * time.Minute
@@ -20,6 +24,10 @@ type Config struct {
 	GRPCAddress              string
 	DatabaseURL              string
 	NotificationsAddress     string
+	AgentsServiceAddress     string
+	AuthorizationAddress     string
+	IdentityResolutionCache  int
+	ThreadAuthorizationCache int
 	ZitiEnabled              bool
 	ZitiManagementAddress    string
 	ZitiServiceName          string
@@ -59,10 +67,30 @@ func FromEnv() (Config, error) {
 		return Config{}, fmt.Errorf("NOTIFICATIONS_ADDRESS must be set")
 	}
 
+	identityCacheSize, err := envInt("IDENTITY_RESOLUTION_CACHE_SIZE", defaultIdentityCacheSize)
+	if err != nil {
+		return Config{}, err
+	}
+	if identityCacheSize <= 0 {
+		return Config{}, fmt.Errorf("IDENTITY_RESOLUTION_CACHE_SIZE must be positive")
+	}
+
+	threadCacheSize, err := envInt("THREAD_AUTH_CACHE_SIZE", defaultThreadAuthCache)
+	if err != nil {
+		return Config{}, err
+	}
+	if threadCacheSize <= 0 {
+		return Config{}, fmt.Errorf("THREAD_AUTH_CACHE_SIZE must be positive")
+	}
+
 	return Config{
 		GRPCAddress:              envOrDefault("GRPC_ADDRESS", defaultGRPCAddress),
 		DatabaseURL:              databaseURL,
 		NotificationsAddress:     notificationsAddress,
+		AgentsServiceAddress:     envOrDefault("AGENTS_SERVICE_ADDRESS", defaultAgentsServiceAddr),
+		AuthorizationAddress:     envOrDefault("AUTHORIZATION_SERVICE_ADDRESS", defaultAuthzServiceAddr),
+		IdentityResolutionCache:  identityCacheSize,
+		ThreadAuthorizationCache: threadCacheSize,
 		ZitiEnabled:              zitiEnabled,
 		ZitiManagementAddress:    envOrDefault("ZITI_MANAGEMENT_ADDRESS", defaultZitiManagementAddr),
 		ZitiServiceName:          envOrDefault("ZITI_SERVICE_NAME", defaultZitiServiceName),
@@ -101,6 +129,20 @@ func envDuration(name string, fallback time.Duration) (time.Duration, error) {
 	parsed, err := time.ParseDuration(value)
 	if err != nil {
 		return 0, fmt.Errorf("%s must be a valid duration: %w", name, err)
+	}
+
+	return parsed, nil
+}
+
+func envInt(name string, fallback int) (int, error) {
+	value := strings.TrimSpace(os.Getenv(name))
+	if value == "" {
+		return fallback, nil
+	}
+
+	parsed, err := strconv.Atoi(value)
+	if err != nil {
+		return 0, fmt.Errorf("%s must be an integer: %w", name, err)
 	}
 
 	return parsed, nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,7 @@ const (
 	defaultGRPCAddress        = ":50051"
 	defaultAgentsServiceAddr  = "agents:50051"
 	defaultAuthzServiceAddr   = "authorization:50051"
+	defaultThreadsServiceAddr = "threads:50051"
 	defaultIdentityCacheSize  = 1000
 	defaultThreadAuthCache    = 1000
 	defaultZitiManagementAddr = "ziti-management:50051"
@@ -26,6 +27,7 @@ type Config struct {
 	NotificationsAddress     string
 	AgentsServiceAddress     string
 	AuthorizationAddress     string
+	ThreadsAddress           string
 	IdentityResolutionCache  int
 	ThreadAuthorizationCache int
 	ZitiEnabled              bool
@@ -89,6 +91,7 @@ func FromEnv() (Config, error) {
 		NotificationsAddress:     notificationsAddress,
 		AgentsServiceAddress:     envOrDefault("AGENTS_SERVICE_ADDRESS", defaultAgentsServiceAddr),
 		AuthorizationAddress:     envOrDefault("AUTHORIZATION_SERVICE_ADDRESS", defaultAuthzServiceAddr),
+		ThreadsAddress:           envOrDefault("THREADS_ADDRESS", defaultThreadsServiceAddr),
 		IdentityResolutionCache:  identityCacheSize,
 		ThreadAuthorizationCache: threadCacheSize,
 		ZitiEnabled:              zitiEnabled,

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -1,0 +1,124 @@
+package identity
+
+import (
+	"context"
+	"fmt"
+
+	identityv1 "github.com/agynio/tracing/.gen/go/agynio/api/identity/v1"
+	"github.com/agynio/tracing/internal/cache"
+)
+
+const (
+	identityUserPrefix = "identity:"
+	threadObjectPrefix = "thread:"
+	threadReadRelation = "can_read"
+)
+
+type ResolvedIdentity struct {
+	IdentityID   string
+	IdentityType identityv1.IdentityType
+}
+
+type AgentIdentity struct {
+	AgentID        string
+	OrganizationID string
+}
+
+type IdentityChain struct {
+	IdentityID     string
+	AgentID        string
+	OrganizationID string
+}
+
+type ZitiResolver interface {
+	ResolveIdentity(ctx context.Context, sourceIdentity string) (ResolvedIdentity, error)
+}
+
+type AgentsResolver interface {
+	ResolveAgentIdentity(ctx context.Context, identityID string) (AgentIdentity, error)
+}
+
+type AuthorizationChecker interface {
+	Check(ctx context.Context, user, relation, object string) (bool, error)
+}
+
+type Resolver struct {
+	zitiResolver   ZitiResolver
+	agentsResolver AgentsResolver
+	cache          *cache.LRU[string, IdentityChain]
+}
+
+func NewResolver(zitiResolver ZitiResolver, agentsResolver AgentsResolver, cache *cache.LRU[string, IdentityChain]) (*Resolver, error) {
+	if zitiResolver == nil {
+		return nil, fmt.Errorf("ziti resolver is required")
+	}
+	if agentsResolver == nil {
+		return nil, fmt.Errorf("agents resolver is required")
+	}
+	if cache == nil {
+		return nil, fmt.Errorf("cache is required")
+	}
+
+	return &Resolver{
+		zitiResolver:   zitiResolver,
+		agentsResolver: agentsResolver,
+		cache:          cache,
+	}, nil
+}
+
+func (r *Resolver) Resolve(ctx context.Context, sourceIdentity string) (IdentityChain, error) {
+	if chain, ok := r.cache.Get(sourceIdentity); ok {
+		return chain, nil
+	}
+
+	resolved, err := r.zitiResolver.ResolveIdentity(ctx, sourceIdentity)
+	if err != nil {
+		return IdentityChain{}, fmt.Errorf("resolve ziti identity: %w", err)
+	}
+	if resolved.IdentityType != identityv1.IdentityType_IDENTITY_TYPE_AGENT {
+		return IdentityChain{}, fmt.Errorf("identity type is not agent: %s", resolved.IdentityType.String())
+	}
+
+	agentIdentity, err := r.agentsResolver.ResolveAgentIdentity(ctx, resolved.IdentityID)
+	if err != nil {
+		return IdentityChain{}, fmt.Errorf("resolve agent identity: %w", err)
+	}
+
+	chain := IdentityChain{
+		IdentityID:     resolved.IdentityID,
+		AgentID:        agentIdentity.AgentID,
+		OrganizationID: agentIdentity.OrganizationID,
+	}
+	r.cache.Add(sourceIdentity, chain)
+	return chain, nil
+}
+
+type ThreadAuthorizer struct {
+	authz AuthorizationChecker
+	cache *cache.LRU[string, bool]
+}
+
+func NewThreadAuthorizer(authz AuthorizationChecker, cache *cache.LRU[string, bool]) (*ThreadAuthorizer, error) {
+	if authz == nil {
+		return nil, fmt.Errorf("authorization checker is required")
+	}
+	if cache == nil {
+		return nil, fmt.Errorf("cache is required")
+	}
+	return &ThreadAuthorizer{authz: authz, cache: cache}, nil
+}
+
+func (t *ThreadAuthorizer) CanRead(ctx context.Context, identityID, threadID string) (bool, error) {
+	cacheKey := identityID + ":" + threadID
+	if allowed, ok := t.cache.Get(cacheKey); ok {
+		return allowed, nil
+	}
+
+	allowed, err := t.authz.Check(ctx, identityUserPrefix+identityID, threadReadRelation, threadObjectPrefix+threadID)
+	if err != nil {
+		return false, err
+	}
+
+	t.cache.Add(cacheKey, allowed)
+	return allowed, nil
+}

--- a/internal/identity/identity.go
+++ b/internal/identity/identity.go
@@ -26,6 +26,7 @@ type AgentIdentity struct {
 
 type IdentityChain struct {
 	IdentityID     string
+	IdentityType   identityv1.IdentityType
 	AgentID        string
 	OrganizationID string
 }
@@ -86,6 +87,7 @@ func (r *Resolver) Resolve(ctx context.Context, sourceIdentity string) (Identity
 
 	chain := IdentityChain{
 		IdentityID:     resolved.IdentityID,
+		IdentityType:   resolved.IdentityType,
 		AgentID:        agentIdentity.AgentID,
 		OrganizationID: agentIdentity.OrganizationID,
 	}

--- a/internal/identity/metadata.go
+++ b/internal/identity/metadata.go
@@ -1,0 +1,29 @@
+package identity
+
+import (
+	"fmt"
+
+	identityv1 "github.com/agynio/tracing/.gen/go/agynio/api/identity/v1"
+)
+
+const (
+	identityTypeAgent  = "agent"
+	identityTypeRunner = "runner"
+	identityTypeUser   = "user"
+	identityTypeApp    = "app"
+)
+
+func IdentityTypeMetadataValue(identityType identityv1.IdentityType) (string, error) {
+	switch identityType {
+	case identityv1.IdentityType_IDENTITY_TYPE_AGENT:
+		return identityTypeAgent, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_RUNNER:
+		return identityTypeRunner, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_USER:
+		return identityTypeUser, nil
+	case identityv1.IdentityType_IDENTITY_TYPE_APP:
+		return identityTypeApp, nil
+	default:
+		return "", fmt.Errorf("unsupported identity type: %s", identityType.String())
+	}
+}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -5,28 +5,91 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"strings"
 
 	collectortracev1 "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	"github.com/agynio/tracing/internal/identity"
 	"github.com/agynio/tracing/internal/notifier"
 	"github.com/agynio/tracing/internal/server"
 	"github.com/agynio/tracing/internal/store"
+	"github.com/agynio/tracing/internal/ziticonn"
+)
+
+const (
+	attrIdentityID     = "agyn.identity.id"
+	attrAgentID        = "agyn.agent.id"
+	attrOrganizationID = "agyn.organization.id"
+	attrThreadID       = "agyn.thread.id"
 )
 
 type Handler struct {
 	collectortracev1.UnimplementedTraceServiceServer
-	store    *store.Store
-	notifier *notifier.Notifier
+	store            *store.Store
+	notifier         *notifier.Notifier
+	identityResolver *identity.Resolver
+	threadAuthorizer *identity.ThreadAuthorizer
 }
 
-func NewHandler(store *store.Store, notifier *notifier.Notifier) *Handler {
-	return &Handler{store: store, notifier: notifier}
+func NewHandler(store *store.Store, notifier *notifier.Notifier, identityResolver *identity.Resolver, threadAuthorizer *identity.ThreadAuthorizer) *Handler {
+	return &Handler{
+		store:            store,
+		notifier:         notifier,
+		identityResolver: identityResolver,
+		threadAuthorizer: threadAuthorizer,
+	}
 }
 
 func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceServiceRequest) (*collectortracev1.ExportTraceServiceResponse, error) {
+	identityChain, hasIdentity, err := h.resolveIdentityChain(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	threadIDs := map[string]struct{}{}
+	for _, resourceSpans := range req.GetResourceSpans() {
+		if resourceSpans == nil {
+			continue
+		}
+		resource := ensureResource(resourceSpans)
+		if hasIdentity {
+			injectIdentity(resource, identityChain)
+		}
+
+		threadID, err := resourceStringAttribute(resource, attrThreadID)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %v", attrThreadID, err)
+		}
+		if threadID != "" {
+			threadIDs[threadID] = struct{}{}
+		}
+	}
+
+	if hasIdentity && len(threadIDs) > 0 {
+		if h.threadAuthorizer == nil {
+			return nil, status.Error(codes.Internal, "thread authorization unavailable")
+		}
+		for threadID := range threadIDs {
+			allowed, err := h.threadAuthorizer.CanRead(ctx, identityChain.IdentityID, threadID)
+			if err != nil {
+				return nil, status.Errorf(codes.Internal, "authorize thread: %v", err)
+			}
+			if !allowed {
+				return nil, status.Error(codes.PermissionDenied, "thread access denied")
+			}
+		}
+	}
+
 	var rejectedSpans int64
 	for _, resourceSpans := range req.GetResourceSpans() {
+		if resourceSpans == nil {
+			continue
+		}
 		resourceData, err := server.MarshalResource(resourceSpans.GetResource())
 		if err != nil {
 			count := countResourceSpans(resourceSpans)
@@ -70,6 +133,24 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 		}
 	}
 	return resp, nil
+}
+
+func (h *Handler) resolveIdentityChain(ctx context.Context) (identity.IdentityChain, bool, error) {
+	if h.identityResolver == nil {
+		return identity.IdentityChain{}, false, nil
+	}
+
+	sourceIdentity, ok := ziticonn.SourceIdentityFromContext(ctx)
+	if !ok {
+		return identity.IdentityChain{}, false, status.Error(codes.Unauthenticated, "source identity missing")
+	}
+
+	chain, err := h.identityResolver.Resolve(ctx, sourceIdentity)
+	if err != nil {
+		return identity.IdentityChain{}, false, status.Errorf(codes.Unauthenticated, "resolve identity: %v", err)
+	}
+
+	return chain, true, nil
 }
 
 func countResourceSpans(resourceSpans *tracev1.ResourceSpans) int {
@@ -183,4 +264,63 @@ func toInt16(value int32, field string) (int16, error) {
 		return 0, fmt.Errorf("%s overflows int16", field)
 	}
 	return int16(value), nil
+}
+
+func ensureResource(resourceSpans *tracev1.ResourceSpans) *resourcev1.Resource {
+	resource := resourceSpans.GetResource()
+	if resource == nil {
+		resource = &resourcev1.Resource{}
+		resourceSpans.Resource = resource
+	}
+	return resource
+}
+
+func injectIdentity(resource *resourcev1.Resource, chain identity.IdentityChain) {
+	upsertResourceAttribute(resource, attrIdentityID, chain.IdentityID)
+	upsertResourceAttribute(resource, attrAgentID, chain.AgentID)
+	upsertResourceAttribute(resource, attrOrganizationID, chain.OrganizationID)
+}
+
+func upsertResourceAttribute(resource *resourcev1.Resource, key, value string) {
+	for _, attr := range resource.Attributes {
+		if attr.GetKey() == key {
+			attr.Value = &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: value}}
+			return
+		}
+	}
+
+	resource.Attributes = append(resource.Attributes, stringAttr(key, value))
+}
+
+func stringAttr(key, value string) *commonv1.KeyValue {
+	return &commonv1.KeyValue{
+		Key:   key,
+		Value: &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: value}},
+	}
+}
+
+func resourceStringAttribute(resource *resourcev1.Resource, key string) (string, error) {
+	if resource == nil {
+		return "", nil
+	}
+	for _, attr := range resource.Attributes {
+		if attr.GetKey() != key {
+			continue
+		}
+		value := attr.GetValue()
+		if value == nil {
+			return "", fmt.Errorf("attribute value missing")
+		}
+		switch typed := value.GetValue().(type) {
+		case *commonv1.AnyValue_StringValue:
+			trimmed := strings.TrimSpace(typed.StringValue)
+			if trimmed == "" {
+				return "", fmt.Errorf("attribute value is empty")
+			}
+			return trimmed, nil
+		default:
+			return "", fmt.Errorf("attribute value must be a string")
+		}
+	}
+	return "", nil
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -30,7 +30,7 @@ const (
 )
 
 type messageVerifier interface {
-	MessageBelongsToThread(ctx context.Context, threadID, messageID string) (bool, error)
+	MessageBelongsToThread(ctx context.Context, identityID, identityType, threadID, messageID string) (bool, error)
 }
 
 type Handler struct {
@@ -115,12 +115,19 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 	}
 
 	if len(messageIDsByThread) > 0 {
+		if !hasIdentity {
+			return nil, status.Error(codes.Unauthenticated, "identity required for message verification")
+		}
 		if h.messageVerifier == nil {
 			return nil, status.Error(codes.Internal, "message verification unavailable")
 		}
+		identityType, err := identity.IdentityTypeMetadataValue(identityChain.IdentityType)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "identity type: %v", err)
+		}
 		for threadID, messageIDs := range messageIDsByThread {
 			for messageID := range messageIDs {
-				ok, err := h.messageVerifier.MessageBelongsToThread(ctx, threadID, messageID)
+				ok, err := h.messageVerifier.MessageBelongsToThread(ctx, identityChain.IdentityID, identityType, threadID, messageID)
 				if err != nil {
 					return nil, status.Errorf(codes.Internal, "verify message: %v", err)
 				}

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -26,7 +26,12 @@ const (
 	attrAgentID        = "agyn.agent.id"
 	attrOrganizationID = "agyn.organization.id"
 	attrThreadID       = "agyn.thread.id"
+	attrMessageID      = "agyn.thread.message.id"
 )
+
+type messageVerifier interface {
+	MessageBelongsToThread(ctx context.Context, threadID, messageID string) (bool, error)
+}
 
 type Handler struct {
 	collectortracev1.UnimplementedTraceServiceServer
@@ -34,14 +39,22 @@ type Handler struct {
 	notifier         *notifier.Notifier
 	identityResolver *identity.Resolver
 	threadAuthorizer *identity.ThreadAuthorizer
+	messageVerifier  messageVerifier
 }
 
-func NewHandler(store *store.Store, notifier *notifier.Notifier, identityResolver *identity.Resolver, threadAuthorizer *identity.ThreadAuthorizer) *Handler {
+func NewHandler(
+	store *store.Store,
+	notifier *notifier.Notifier,
+	identityResolver *identity.Resolver,
+	threadAuthorizer *identity.ThreadAuthorizer,
+	messageVerifier messageVerifier,
+) *Handler {
 	return &Handler{
 		store:            store,
 		notifier:         notifier,
 		identityResolver: identityResolver,
 		threadAuthorizer: threadAuthorizer,
+		messageVerifier:  messageVerifier,
 	}
 }
 
@@ -52,6 +65,7 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 	}
 
 	threadIDs := map[string]struct{}{}
+	messageIDsByThread := map[string]map[string]struct{}{}
 	for _, resourceSpans := range req.GetResourceSpans() {
 		if resourceSpans == nil {
 			continue
@@ -65,8 +79,23 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %v", attrThreadID, err)
 		}
+		messageID, err := resourceStringAttribute(resource, attrMessageID)
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "invalid %s: %v", attrMessageID, err)
+		}
+		if messageID != "" && threadID == "" {
+			return nil, status.Error(codes.InvalidArgument, "thread id is required for message verification")
+		}
 		if threadID != "" {
 			threadIDs[threadID] = struct{}{}
+		}
+		if messageID != "" {
+			messageIDs := messageIDsByThread[threadID]
+			if messageIDs == nil {
+				messageIDs = map[string]struct{}{}
+				messageIDsByThread[threadID] = messageIDs
+			}
+			messageIDs[messageID] = struct{}{}
 		}
 	}
 
@@ -81,6 +110,23 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 			}
 			if !allowed {
 				return nil, status.Error(codes.PermissionDenied, "thread access denied")
+			}
+		}
+	}
+
+	if len(messageIDsByThread) > 0 {
+		if h.messageVerifier == nil {
+			return nil, status.Error(codes.Internal, "message verification unavailable")
+		}
+		for threadID, messageIDs := range messageIDsByThread {
+			for messageID := range messageIDs {
+				ok, err := h.messageVerifier.MessageBelongsToThread(ctx, threadID, messageID)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "verify message: %v", err)
+				}
+				if !ok {
+					return nil, status.Errorf(codes.InvalidArgument, "message id %s does not belong to thread %s", messageID, threadID)
+				}
 			}
 		}
 	}
@@ -282,14 +328,15 @@ func injectIdentity(resource *resourcev1.Resource, chain identity.IdentityChain)
 }
 
 func upsertResourceAttribute(resource *resourcev1.Resource, key, value string) {
+	attrs := make([]*commonv1.KeyValue, 0, len(resource.Attributes)+1)
 	for _, attr := range resource.Attributes {
 		if attr.GetKey() == key {
-			attr.Value = &commonv1.AnyValue{Value: &commonv1.AnyValue_StringValue{StringValue: value}}
-			return
+			continue
 		}
+		attrs = append(attrs, attr)
 	}
-
-	resource.Attributes = append(resource.Attributes, stringAttr(key, value))
+	attrs = append(attrs, stringAttr(key, value))
+	resource.Attributes = attrs
 }
 
 func stringAttr(key, value string) *commonv1.KeyValue {

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -4,7 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/agynio/tracing/internal/identity"
 )
 
 func TestSpanToRowNormalizesParentSpanID(t *testing.T) {
@@ -20,4 +24,41 @@ func TestSpanToRowNormalizesParentSpanID(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, row.ParentSpanID)
 	require.Len(t, row.ParentSpanID, 0)
+}
+
+func TestInjectIdentityDedupesAttributes(t *testing.T) {
+	resource := &resourcev1.Resource{Attributes: []*commonv1.KeyValue{
+		stringAttr(attrIdentityID, "old-identity"),
+		stringAttr("other", "keep"),
+		stringAttr(attrIdentityID, "duplicate"),
+		stringAttr(attrAgentID, "old-agent"),
+		stringAttr(attrOrganizationID, "old-org"),
+		stringAttr(attrOrganizationID, "duplicate-org"),
+	}}
+
+	injectIdentity(resource, identity.IdentityChain{
+		IdentityID:     "identity",
+		AgentID:        "agent",
+		OrganizationID: "organization",
+	})
+
+	require.Equal(t, []string{"identity"}, attrValues(resource.Attributes, attrIdentityID))
+	require.Equal(t, []string{"agent"}, attrValues(resource.Attributes, attrAgentID))
+	require.Equal(t, []string{"organization"}, attrValues(resource.Attributes, attrOrganizationID))
+	require.Equal(t, []string{"keep"}, attrValues(resource.Attributes, "other"))
+}
+
+func attrValues(attrs []*commonv1.KeyValue, key string) []string {
+	values := []string{}
+	for _, attr := range attrs {
+		if attr.GetKey() != key {
+			continue
+		}
+		if value := attr.GetValue(); value != nil {
+			if typed, ok := value.GetValue().(*commonv1.AnyValue_StringValue); ok {
+				values = append(values, typed.StringValue)
+			}
+		}
+	}
+	return values
 }

--- a/internal/threadsclient/client.go
+++ b/internal/threadsclient/client.go
@@ -7,6 +7,7 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	threadsv1 "github.com/agynio/tracing/.gen/go/agynio/api/threads/v1"
 )
@@ -38,15 +39,31 @@ func (c *Client) Close() error {
 	return c.conn.Close()
 }
 
-func (c *Client) MessageBelongsToThread(ctx context.Context, threadID, messageID string) (bool, error) {
+func (c *Client) MessageBelongsToThread(ctx context.Context, identityID, identityType, threadID, messageID string) (bool, error) {
+	identityID = strings.TrimSpace(identityID)
+	identityType = strings.TrimSpace(identityType)
 	threadID = strings.TrimSpace(threadID)
 	messageID = strings.TrimSpace(messageID)
+	if identityID == "" {
+		return false, fmt.Errorf("identity id is required")
+	}
+	if identityType == "" {
+		return false, fmt.Errorf("identity type is required")
+	}
 	if threadID == "" {
 		return false, fmt.Errorf("thread id is required")
 	}
 	if messageID == "" {
 		return false, fmt.Errorf("message id is required")
 	}
+
+	ctx = metadata.AppendToOutgoingContext(
+		ctx,
+		"x-identity-id",
+		identityID,
+		"x-identity-type",
+		identityType,
+	)
 
 	pageToken := ""
 	for {

--- a/internal/threadsclient/client.go
+++ b/internal/threadsclient/client.go
@@ -1,0 +1,75 @@
+package threadsclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	threadsv1 "github.com/agynio/tracing/.gen/go/agynio/api/threads/v1"
+)
+
+const messagePageSize int32 = 200
+
+type Client struct {
+	conn   *grpc.ClientConn
+	client threadsv1.ThreadsServiceClient
+}
+
+func NewClient(target string) (*Client, error) {
+	if strings.TrimSpace(target) == "" {
+		return nil, fmt.Errorf("target is required")
+	}
+
+	conn, err := grpc.NewClient(target, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Client{
+		conn:   conn,
+		client: threadsv1.NewThreadsServiceClient(conn),
+	}, nil
+}
+
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+func (c *Client) MessageBelongsToThread(ctx context.Context, threadID, messageID string) (bool, error) {
+	threadID = strings.TrimSpace(threadID)
+	messageID = strings.TrimSpace(messageID)
+	if threadID == "" {
+		return false, fmt.Errorf("thread id is required")
+	}
+	if messageID == "" {
+		return false, fmt.Errorf("message id is required")
+	}
+
+	pageToken := ""
+	for {
+		resp, err := c.client.GetMessages(ctx, &threadsv1.GetMessagesRequest{
+			ThreadId:  threadID,
+			PageSize:  messagePageSize,
+			PageToken: pageToken,
+			Order:     threadsv1.MessageOrder_MESSAGE_ORDER_OLDEST_FIRST,
+		})
+		if err != nil {
+			return false, err
+		}
+
+		for _, message := range resp.GetMessages() {
+			if strings.TrimSpace(message.GetId()) == messageID {
+				return true, nil
+			}
+		}
+
+		nextToken := strings.TrimSpace(resp.GetNextPageToken())
+		if nextToken == "" {
+			return false, nil
+		}
+		pageToken = nextToken
+	}
+}

--- a/internal/ziticonn/identity.go
+++ b/internal/ziticonn/identity.go
@@ -1,0 +1,89 @@
+package ziticonn
+
+import (
+	"context"
+	"net"
+	"strings"
+
+	"google.golang.org/grpc/peer"
+)
+
+type dialerIdentityConn interface {
+	GetDialerIdentityId() string
+}
+
+type identityAddr struct {
+	net.Addr
+	identity string
+}
+
+func (a identityAddr) DialerIdentity() string {
+	return a.identity
+}
+
+type identityConn struct {
+	net.Conn
+	remoteAddr net.Addr
+}
+
+func (c *identityConn) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}
+
+type wrappedListener struct {
+	net.Listener
+}
+
+func WrapListener(listener net.Listener) net.Listener {
+	return &wrappedListener{Listener: listener}
+}
+
+func (w *wrappedListener) Accept() (net.Conn, error) {
+	conn, err := w.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	identity := dialerIdentityFromConn(conn)
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return conn, nil
+	}
+
+	return &identityConn{
+		Conn:       conn,
+		remoteAddr: identityAddr{Addr: conn.RemoteAddr(), identity: identity},
+	}, nil
+}
+
+func SourceIdentityFromContext(ctx context.Context) (string, bool) {
+	peerInfo, ok := peer.FromContext(ctx)
+	if !ok || peerInfo == nil || peerInfo.Addr == nil {
+		return "", false
+	}
+
+	identity, ok := dialerIdentityFromAddr(peerInfo.Addr)
+	if !ok {
+		return "", false
+	}
+	identity = strings.TrimSpace(identity)
+	if identity == "" {
+		return "", false
+	}
+
+	return identity, true
+}
+
+func dialerIdentityFromConn(conn net.Conn) string {
+	if identityConn, ok := conn.(dialerIdentityConn); ok {
+		return identityConn.GetDialerIdentityId()
+	}
+	return ""
+}
+
+func dialerIdentityFromAddr(addr net.Addr) (string, bool) {
+	if identityAddr, ok := addr.(interface{ DialerIdentity() string }); ok {
+		return identityAddr.DialerIdentity(), true
+	}
+	return "", false
+}

--- a/internal/zitimgmtclient/client.go
+++ b/internal/zitimgmtclient/client.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	zitimgmtv1 "github.com/agynio/tracing/.gen/go/agynio/api/ziti_management/v1"
+	"github.com/agynio/tracing/internal/identity"
 )
 
 type Client struct {
@@ -71,4 +72,31 @@ func (c *Client) ExtendIdentityLease(ctx context.Context, zitiIdentityID string)
 		ZitiIdentityId: trimmed,
 	})
 	return err
+}
+
+func (c *Client) ResolveIdentity(ctx context.Context, sourceIdentity string) (identity.ResolvedIdentity, error) {
+	trimmed := strings.TrimSpace(sourceIdentity)
+	if trimmed == "" {
+		return identity.ResolvedIdentity{}, fmt.Errorf("source identity is required")
+	}
+
+	response, err := c.client.ResolveIdentity(ctx, &zitimgmtv1.ResolveIdentityRequest{ZitiIdentityId: trimmed})
+	if err != nil {
+		return identity.ResolvedIdentity{}, err
+	}
+
+	identityID := strings.TrimSpace(response.GetIdentityId())
+	if identityID == "" {
+		return identity.ResolvedIdentity{}, fmt.Errorf("identity id missing")
+	}
+
+	identityType := response.GetIdentityType()
+	if identityType == 0 {
+		return identity.ResolvedIdentity{}, fmt.Errorf("identity type missing")
+	}
+
+	return identity.ResolvedIdentity{
+		IdentityID:   identityID,
+		IdentityType: identityType,
+	}, nil
 }


### PR DESCRIPTION
## Summary
- resolve Ziti identities, enrich span resources with identity/agent/org and dedupe attrs
- verify thread access plus thread message ownership via Threads
- add agents/authz/threads clients and update buf generation paths

## Testing
- buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1
- go test ./...
- go vet ./...
- go build ./...

Refs agynio/architecture#136