### PR TITLE
fix(tracing): update Dockerfile buf paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
 COPY buf.gen.yaml buf.yaml ./
-RUN buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1
+RUN buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1
 
 COPY . .
 


### PR DESCRIPTION
## Summary
- update Dockerfile buf generate step to include agents/authz/threads paths
- align image build with CI-generated bindings

## Testing
- buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1
- go test ./...
- go vet ./...
- go build ./...
- docker buildx build --load -t tracing:test .

Refs agynio/architecture#136