### PR TITLE
feat: include org id in span notifications

### DIFF
--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -143,6 +143,12 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 		if resourceSpans == nil {
 			continue
 		}
+		resource := resourceSpans.GetResource()
+		organizationID, err := resourceStringAttribute(resource, attrOrganizationID)
+		if err != nil {
+			log.Printf("ingest: invalid %s: %v", attrOrganizationID, err)
+			organizationID = ""
+		}
 		resourceData, err := server.MarshalResource(resourceSpans.GetResource())
 		if err != nil {
 			count := countResourceSpans(resourceSpans)
@@ -171,7 +177,7 @@ func (h *Handler) Export(ctx context.Context, req *collectortracev1.ExportTraceS
 					log.Printf("ingest: upsert span: %v", err)
 					continue
 				}
-				if err := h.notifier.PublishSpanEvent(ctx, row.TraceID, row.SpanID, isNew); err != nil {
+				if err := h.notifier.PublishSpanEvent(ctx, row.TraceID, row.SpanID, organizationID, isNew); err != nil {
 					log.Printf("ingest: publish span event: %v", err)
 				}
 			}

--- a/internal/notifier/notifier.go
+++ b/internal/notifier/notifier.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	notificationsv1 "github.com/agynio/tracing/.gen/go/agynio/api/notifications/v1"
@@ -24,16 +26,25 @@ func New(client notificationsv1.NotificationsServiceClient) *Notifier {
 	return &Notifier{client: client}
 }
 
-func (n *Notifier) PublishSpanEvent(ctx context.Context, traceID, spanID []byte, isNew bool) error {
+func (n *Notifier) PublishSpanEvent(ctx context.Context, traceID, spanID []byte, organizationID string, isNew bool) error {
 	event := spanUpdatedEvent
 	if isNew {
 		event = spanCreatedEvent
 	}
+	trimmedOrgID := strings.TrimSpace(organizationID)
+	if trimmedOrgID == "" {
+		return fmt.Errorf("organization id required")
+	}
+	parsedOrgID, err := uuid.Parse(trimmedOrgID)
+	if err != nil {
+		return fmt.Errorf("invalid organization id: %w", err)
+	}
 	traceHex := hex.EncodeToString(traceID)
 	spanHex := hex.EncodeToString(spanID)
 	payload, err := structpb.NewStruct(map[string]any{
-		"trace_id": traceHex,
-		"span_id":  spanHex,
+		"trace_id":        traceHex,
+		"span_id":         spanHex,
+		"organization_id": parsedOrgID.String(),
 	})
 	if err != nil {
 		return fmt.Errorf("build payload: %w", err)


### PR DESCRIPTION
## Summary
- validate and include organization_id in span created/updated notification payloads
- derive organization_id from resource attributes when publishing span events

## Testing
- buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1
- go test ./...
- go vet ./...
- go build ./...

Related: https://github.com/agynio/architecture/issues/142
#142