### PR TITLE
fix: prefer app spans for message trace lookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/openziti/transport/v2 v2.0.215 // indirect
 	github.com/orcaman/concurrent-map/v2 v2.0.1 // indirect
 	github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9 // indirect
+	github.com/pashagolub/pgxmock/v4 v4.9.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/orcaman/concurrent-map/v2 v2.0.1/go.mod h1:9Eq3TG2oBe5FirmYWQfYO5iH1q
 github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9 h1:mOvehYivJ4Aqu2CPe3D3lv8jhqOI9/1o0THxJHBE0qw=
 github.com/parallaxsecond/parsec-client-go v0.0.0-20221025095442-f0a77d263cf9/go.mod h1:gLH27qo/dvMhLTVVyMELpe3Tut7sOfkiDg7ZpeqKwsw=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
+github.com/pashagolub/pgxmock/v4 v4.9.0 h1:itlO8nrVRnzkdMBXLs8pWUyyB2PC3Gku0WGIj/gGl7I=
+github.com/pashagolub/pgxmock/v4 v4.9.0/go.mod h1:9L57pC193h2aKRHVyiiE817avasIPZnPwPlw3JczWvM=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,6 +126,9 @@ func (s *Server) GetTraceSummary(ctx context.Context, req *tracingv1.GetTraceSum
 		okCount += row.OkCount
 		errorCount += row.ErrorCount
 	}
+	for category, count := range summary.CategoryCounts {
+		countsByName[string(category)] = count
+	}
 	countsByStatus := map[string]int64{
 		tracingv1.SpanStatus_SPAN_STATUS_RUNNING.String(): runningCount,
 		tracingv1.SpanStatus_SPAN_STATUS_OK.String():      okCount,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,10 +20,18 @@ const (
 
 type Server struct {
 	tracingv1.UnimplementedTracingServiceServer
-	store *store.Store
+	store spanStore
 }
 
-func New(store *store.Store) *Server {
+type spanStore interface {
+	ListSpans(ctx context.Context, filter store.SpanFilter, pageSize int32, cursor *store.SpanCursor, orderBy store.OrderBy) (store.SpanListResult, error)
+	GetSpan(ctx context.Context, traceID, spanID []byte) (store.SpanRow, error)
+	GetTrace(ctx context.Context, traceID []byte) ([]store.SpanRow, error)
+	GetTraceSummary(ctx context.Context, traceID []byte) (store.TraceSummary, error)
+	GetTraceSpanTotals(ctx context.Context, filter store.TraceSpanTotalsFilter) (store.TraceSpanTotals, error)
+}
+
+func New(store spanStore) *Server {
 	return &Server{store: store}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,14 +2,59 @@ package server
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	tracingv1 "github.com/agynio/tracing/.gen/go/agynio/api/tracing/v1"
+	"github.com/agynio/tracing/internal/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+type mockSpanStore struct {
+	listSpans          func(ctx context.Context, filter store.SpanFilter, pageSize int32, cursor *store.SpanCursor, orderBy store.OrderBy) (store.SpanListResult, error)
+	getSpan            func(ctx context.Context, traceID, spanID []byte) (store.SpanRow, error)
+	getTrace           func(ctx context.Context, traceID []byte) ([]store.SpanRow, error)
+	getTraceSummary    func(ctx context.Context, traceID []byte) (store.TraceSummary, error)
+	getTraceSpanTotals func(ctx context.Context, filter store.TraceSpanTotalsFilter) (store.TraceSpanTotals, error)
+}
+
+func (m *mockSpanStore) ListSpans(ctx context.Context, filter store.SpanFilter, pageSize int32, cursor *store.SpanCursor, orderBy store.OrderBy) (store.SpanListResult, error) {
+	if m.listSpans == nil {
+		return store.SpanListResult{}, errors.New("not implemented")
+	}
+	return m.listSpans(ctx, filter, pageSize, cursor, orderBy)
+}
+
+func (m *mockSpanStore) GetSpan(ctx context.Context, traceID, spanID []byte) (store.SpanRow, error) {
+	if m.getSpan == nil {
+		return store.SpanRow{}, errors.New("not implemented")
+	}
+	return m.getSpan(ctx, traceID, spanID)
+}
+
+func (m *mockSpanStore) GetTrace(ctx context.Context, traceID []byte) ([]store.SpanRow, error) {
+	if m.getTrace == nil {
+		return nil, errors.New("not implemented")
+	}
+	return m.getTrace(ctx, traceID)
+}
+
+func (m *mockSpanStore) GetTraceSummary(ctx context.Context, traceID []byte) (store.TraceSummary, error) {
+	if m.getTraceSummary == nil {
+		return store.TraceSummary{}, errors.New("not implemented")
+	}
+	return m.getTraceSummary(ctx, traceID)
+}
+
+func (m *mockSpanStore) GetTraceSpanTotals(ctx context.Context, filter store.TraceSpanTotalsFilter) (store.TraceSpanTotals, error) {
+	if m.getTraceSpanTotals == nil {
+		return store.TraceSpanTotals{}, errors.New("not implemented")
+	}
+	return m.getTraceSpanTotals(ctx, filter)
+}
 
 func TestListSpansRequiresOrganizationID(t *testing.T) {
 	server := New(nil)
@@ -20,4 +65,40 @@ func TestListSpansRequiresOrganizationID(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, codes.InvalidArgument, statusErr.Code())
 	assert.Contains(t, statusErr.Message(), "organization_id")
+}
+
+func TestGetTraceSummaryMapsCategoryCountsByName(t *testing.T) {
+	traceID := []byte("1234567890123456")
+	server := New(&mockSpanStore{
+		getTraceSummary: func(_ context.Context, gotTraceID []byte) (store.TraceSummary, error) {
+			assert.Equal(t, traceID, gotTraceID)
+			return store.TraceSummary{
+				TraceID:            gotTraceID,
+				TotalSpans:         7,
+				FirstSpanStartTime: 10,
+				LastSpanStartTime:  20,
+				LastSpanEndTime:    30,
+				Rows: []store.TraceSummaryRow{
+					{Name: "chat.completions", NameCount: 3, OkCount: 3},
+				},
+				CategoryCounts: map[store.SpanCategory]int64{
+					store.SpanCategoryMessage: 1,
+					store.SpanCategoryLLM:     3,
+					store.SpanCategoryTool:    2,
+				},
+			}, nil
+		},
+	})
+
+	resp, err := server.GetTraceSummary(context.Background(), &tracingv1.GetTraceSummaryRequest{TraceId: traceID})
+	require.NoError(t, err)
+
+	assert.Equal(t, traceID, resp.GetTraceId())
+	assert.Equal(t, tracingv1.TraceStatus_TRACE_STATUS_COMPLETED, resp.GetStatus())
+	assert.Equal(t, int64(3), resp.GetCountsByName()["chat.completions"])
+	assert.Equal(t, int64(1), resp.GetCountsByName()["message"])
+	assert.Equal(t, int64(3), resp.GetCountsByName()["llm"])
+	assert.Equal(t, int64(2), resp.GetCountsByName()["tool"])
+	assert.Equal(t, int64(3), resp.GetCountsByStatus()[tracingv1.SpanStatus_SPAN_STATUS_OK.String()])
+	assert.Equal(t, int64(7), resp.GetTotalSpans())
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -20,10 +21,20 @@ const (
 )
 
 type Store struct {
-	pool *pgxpool.Pool
+	pool querier
 }
 
 func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+type querier interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	Query(ctx context.Context, sql string, args ...any) (pgx.Rows, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func newStoreWithQuerier(pool querier) *Store {
 	return &Store{pool: pool}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -13,6 +13,10 @@ import (
 const (
 	spanColumns        = "trace_id, span_id, trace_state, parent_span_id, flags, name, kind, start_time_unix_nano, end_time_unix_nano, attributes, dropped_attributes_count, events, dropped_events_count, links, dropped_links_count, status_code, status_message, resource, instrumentation_scope"
 	spanStatusCaseExpr = "CASE WHEN end_time_unix_nano = 0 AND status_code != 2 THEN 1 WHEN end_time_unix_nano > 0 AND status_code != 2 THEN 2 WHEN status_code = 2 THEN 3 END"
+	messageSpanExpr    = "(name = 'invocation.message' OR attributes @> '[{\"key\": \"agyn.message.text\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.message.role\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.message.kind\"}]'::jsonb)"
+	llmSpanExpr        = "(name = 'llm.call' OR attributes @> '[{\"key\": \"gen_ai.system\"}]'::jsonb OR attributes @> '[{\"key\": \"gen_ai.request.model\"}]'::jsonb OR attributes @> '[{\"key\": \"gen_ai.response.finish_reason\"}]'::jsonb)"
+	toolSpanExpr       = "(name = 'tool.execution' OR attributes @> '[{\"key\": \"agyn.tool.name\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.tool.input\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.tool.output\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.tool.call_id\"}]'::jsonb)"
+	appSpanExpr        = "(" + messageSpanExpr + " OR " + llmSpanExpr + " OR " + toolSpanExpr + " OR name = 'summarization' OR attributes @> '[{\"key\": \"agyn.summarization.text\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.summarization.new_context_count\"}]'::jsonb OR attributes @> '[{\"key\": \"agyn.summarization.old_context_tokens\"}]'::jsonb)"
 )
 
 type Store struct {
@@ -206,7 +210,30 @@ func (s *Store) GetTraceSummary(ctx context.Context, traceID []byte) (TraceSumma
 	if !initialized {
 		return TraceSummary{}, ErrTraceNotFound
 	}
+	categoryCounts, err := s.getTraceCategoryCounts(ctx, traceID)
+	if err != nil {
+		return TraceSummary{}, err
+	}
+	summary.CategoryCounts = categoryCounts
 	return summary, nil
+}
+
+func (s *Store) getTraceCategoryCounts(ctx context.Context, traceID []byte) (map[SpanCategory]int64, error) {
+	query := fmt.Sprintf(`SELECT
+		COALESCE(sum(CASE WHEN %s THEN 1 ELSE 0 END), 0) AS message_count,
+		COALESCE(sum(CASE WHEN %s THEN 1 ELSE 0 END), 0) AS llm_count,
+		COALESCE(sum(CASE WHEN %s THEN 1 ELSE 0 END), 0) AS tool_count
+	FROM spans
+	WHERE trace_id = $1`, messageSpanExpr, llmSpanExpr, toolSpanExpr)
+	categoryCounts := map[SpanCategory]int64{}
+	var messageCount, llmCount, toolCount int64
+	if err := s.pool.QueryRow(ctx, query, traceID).Scan(&messageCount, &llmCount, &toolCount); err != nil {
+		return nil, err
+	}
+	categoryCounts[SpanCategoryMessage] = messageCount
+	categoryCounts[SpanCategoryLLM] = llmCount
+	categoryCounts[SpanCategoryTool] = toolCount
+	return categoryCounts, nil
 }
 
 func (s *Store) GetTraceSpanTotals(ctx context.Context, filter TraceSpanTotalsFilter) (TraceSpanTotals, error) {
@@ -282,6 +309,9 @@ func (s *Store) ListSpans(ctx context.Context, filter SpanFilter, pageSize int32
 		conditions = append(conditions, fmt.Sprintf("message_id = $%d", paramIndex))
 		args = append(args, filter.MessageID)
 		paramIndex++
+		if len(filter.TraceID) == 0 && filter.Name == "" && len(filter.Names) == 0 && filter.Kind == 0 && len(filter.ParentSpanID) == 0 {
+			conditions = append(conditions, appSpanExpr)
+		}
 	}
 	if len(filter.ParentSpanID) > 0 {
 		conditions = append(conditions, fmt.Sprintf("parent_span_id = $%d", paramIndex))

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+	pgxmock "github.com/pashagolub/pgxmock/v4"
+)
+
+func TestListSpansMessageIDPrefersApplicationSpans(t *testing.T) {
+	matcher := newQueryRecorder(t)
+	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(matcher))
+	if err != nil {
+		t.Fatalf("create pgx mock: %v", err)
+	}
+	defer mock.Close()
+
+	filter := SpanFilter{
+		OrganizationID: "org-id",
+		MessageID:      "message-id",
+	}
+
+	mock.ExpectQuery("list message spans").
+		WithArgs(filter.OrganizationID, filter.MessageID, 51).
+		WillReturnRows(emptySpanRows())
+
+	_, err = newStoreWithQuerier(mock).ListSpans(context.Background(), filter, 50, nil, OrderByStartTimeDesc)
+	if err != nil {
+		t.Fatalf("list spans: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+
+	query := matcher.queries[0]
+	if !containsAll(query, "message_id = $2", "invocation.message", "gen_ai.system", "agyn.tool.name") {
+		t.Fatalf("expected message lookup to include application span preference, got %s", query)
+	}
+}
+
+func TestListSpansMessageIDTraceScopedKeepsExactTrace(t *testing.T) {
+	matcher := newQueryRecorder(t)
+	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(matcher))
+	if err != nil {
+		t.Fatalf("create pgx mock: %v", err)
+	}
+	defer mock.Close()
+
+	filter := SpanFilter{
+		OrganizationID: "org-id",
+		TraceID:        []byte("trace-id-0000000"),
+		MessageID:      "message-id",
+	}
+
+	mock.ExpectQuery("list trace message spans").
+		WithArgs(filter.OrganizationID, filter.TraceID, filter.MessageID, 51).
+		WillReturnRows(emptySpanRows())
+
+	_, err = newStoreWithQuerier(mock).ListSpans(context.Background(), filter, 50, nil, OrderByStartTimeDesc)
+	if err != nil {
+		t.Fatalf("list spans: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+
+	query := matcher.queries[0]
+	if !containsAll(query, "trace_id = $2", "message_id = $3") {
+		t.Fatalf("expected trace-scoped message query, got %s", query)
+	}
+	if containsAll(query, "gen_ai.system", "agyn.tool.name") {
+		t.Fatalf("expected trace-scoped message query to avoid app-span preference, got %s", query)
+	}
+}
+
+func TestGetTraceSummaryIncludesCategoryCounts(t *testing.T) {
+	matcher := newQueryRecorder(t)
+	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(matcher))
+	if err != nil {
+		t.Fatalf("create pgx mock: %v", err)
+	}
+	defer mock.Close()
+
+	traceID := []byte("trace-id-0000000")
+	mock.ExpectQuery("trace summary names").
+		WithArgs(traceID).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"name",
+			"name_count",
+			"first_start",
+			"last_start",
+			"last_end",
+			"running_count",
+			"ok_count",
+			"error_count",
+		}).AddRow("chat.completions", int64(2), int64(10), int64(20), int64(30), int64(0), int64(2), int64(0)))
+	mock.ExpectQuery("trace summary categories").
+		WithArgs(traceID).
+		WillReturnRows(pgxmock.NewRows([]string{
+			"message_count",
+			"llm_count",
+			"tool_count",
+		}).AddRow(int64(1), int64(2), int64(1)))
+
+	summary, err := newStoreWithQuerier(mock).GetTraceSummary(context.Background(), traceID)
+	if err != nil {
+		t.Fatalf("get trace summary: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+
+	if summary.CategoryCounts[SpanCategoryMessage] != 1 {
+		t.Fatalf("expected message count 1, got %d", summary.CategoryCounts[SpanCategoryMessage])
+	}
+	if summary.CategoryCounts[SpanCategoryLLM] != 2 {
+		t.Fatalf("expected llm count 2, got %d", summary.CategoryCounts[SpanCategoryLLM])
+	}
+	if summary.CategoryCounts[SpanCategoryTool] != 1 {
+		t.Fatalf("expected tool count 1, got %d", summary.CategoryCounts[SpanCategoryTool])
+	}
+
+	categoryQuery := matcher.queries[1]
+	if !containsAll(categoryQuery, "gen_ai.system", "gen_ai.request.model", "agyn.tool.name", "agyn.message.text") {
+		t.Fatalf("expected provider-specific category classification, got %s", categoryQuery)
+	}
+}
+
+func emptySpanRows() *pgxmock.Rows {
+	return pgxmock.NewRows([]string{
+		"trace_id",
+		"span_id",
+		"trace_state",
+		"parent_span_id",
+		"flags",
+		"name",
+		"kind",
+		"start_time_unix_nano",
+		"end_time_unix_nano",
+		"attributes",
+		"dropped_attributes_count",
+		"events",
+		"dropped_events_count",
+		"links",
+		"dropped_links_count",
+		"status_code",
+		"status_message",
+		"resource",
+		"instrumentation_scope",
+	})
+}
+
+func containsAll(value string, parts ...string) bool {
+	for _, part := range parts {
+		if !regexp.MustCompile(regexp.QuoteMeta(part)).MatchString(value) {
+			return false
+		}
+	}
+	return true
+}
+
+type queryRecorder struct {
+	t       *testing.T
+	queries []string
+}
+
+func newQueryRecorder(t *testing.T) *queryRecorder {
+	t.Helper()
+	return &queryRecorder{t: t}
+}
+
+func (r *queryRecorder) Match(expectedSQL, actualSQL string) error {
+	if strings.TrimSpace(actualSQL) == "" {
+		return errors.New("query is empty")
+	}
+	r.queries = append(r.queries, actualSQL)
+	return nil
+}
+
+var _ pgxmock.QueryMatcher = (*queryRecorder)(nil)
+
+var _ querier = (pgxmock.PgxPoolIface)(nil)
+var _ querier = (*pgxpool.Pool)(nil)
+var _ = pgconn.CommandTag{}

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -51,6 +51,14 @@ type SpanFilter struct {
 	MessageID      string
 }
 
+type SpanCategory string
+
+const (
+	SpanCategoryMessage SpanCategory = "message"
+	SpanCategoryLLM     SpanCategory = "llm"
+	SpanCategoryTool    SpanCategory = "tool"
+)
+
 type TraceSummary struct {
 	TraceID            []byte
 	TotalSpans         int64
@@ -58,6 +66,7 @@ type TraceSummary struct {
 	LastSpanStartTime  int64
 	LastSpanEndTime    int64
 	Rows               []TraceSummaryRow
+	CategoryCounts     map[SpanCategory]int64
 }
 
 type TraceSummaryRow struct {

--- a/test/e2e/spans_test.go
+++ b/test/e2e/spans_test.go
@@ -763,6 +763,7 @@ func TestListSpansFiltering(t *testing.T) {
 
 func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
 	traceID := newTraceID()
+	transportTraceID := newTraceID()
 	threadID := fmt.Sprintf("thread-%x", traceID)
 	startNs := uint64(time.Now().UnixNano())
 	orgSpan := buildSpan(
@@ -789,10 +790,19 @@ func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
 		startNs+5_000_000,
 		toolExecutionAttrs("org.tool", "{}", "ok", "call-org"),
 	)
+	transportSpan := buildSpan(
+		"h2.grpc.client",
+		transportTraceID,
+		newSpanID(),
+		startNs+6_000_000,
+		startNs+7_000_000,
+		[]*commonv1.KeyValue{stringAttr("rpc.system", "grpc")},
+	)
 	resourceSpans := []*tracev1.ResourceSpans{
 		buildResourceSpans([]*tracev1.Span{orgSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, defaultMessageID)),
 		buildResourceSpans([]*tracev1.Span{messageSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, otherMessageID)),
 		buildResourceSpans([]*tracev1.Span{otherOrgSpan}, resourceAttrsWithMessageID(threadID, otherOrganizationID, defaultMessageID)),
+		buildResourceSpans([]*tracev1.Span{transportSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, defaultMessageID)),
 	}
 
 	collectorClient, queryClient := newTracingClients(t)
@@ -839,6 +849,28 @@ func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
 			return
 		}
 		assert.Equal(c, spanInvocationMessage, spans[0].GetName())
+		assert.Equal(c, traceID, spans[0].GetTraceId())
+	})
+
+	requireEventually(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
+			Filter: &tracingv1.SpanFilter{
+				TraceId:   transportTraceID,
+				MessageId: defaultMessageID,
+			},
+		})
+		assert.NoError(c, err)
+		if err != nil {
+			return
+		}
+		spans := flattenSpans(listResp.GetResourceSpans())
+		if !assert.Len(c, spans, 1) {
+			return
+		}
+		assert.Equal(c, "h2.grpc.client", spans[0].GetName())
 	})
 
 	requireEventually(t, func(c *assert.CollectT) {


### PR DESCRIPTION
## Summary
- Keep `ListSpans(filter: { message_id })` focused on agent application spans when no more-specific filter is supplied, so message-based trace discovery does not select low-level transport traces first.
- Preserve exact message + trace lookups for explicit trace-scoped queries.
- Add trace summary category counts (`message`, `llm`, `tool`) derived from canonical span names or application attributes so UI/E2E summaries can still report non-zero run counts when producers use provider-specific span names.
- Extend E2E coverage for message filtering with a same-message transport span.

Closes #19

## Test & Lint Summary
- `~/go/bin/buf generate buf.build/agynio/api --path agynio/api/tracing/v1 --path agynio/api/notifications/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 --path agynio/api/agents/v1 --path agynio/api/authorization/v1 --path agynio/api/threads/v1`
- `go test ./...`: 4 packages passed, 0 failed, 0 skipped; remaining packages had no test files
- `go build ./...`: passed with no errors
- `go test ./test/e2e -tags e2e -run TestListSpansOrganizationAndMessageFilters`: not part of final pass because it requires a live tracing E2E environment; local attempt reached the service but failed existing fixture auth with `PermissionDenied: thread access denied`