### PR TITLE
fix(tracing): index span-level message IDs

### DIFF
--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -43,6 +43,40 @@ func TestListSpansMessageIDPrefersApplicationSpans(t *testing.T) {
 	}
 }
 
+func TestListSpansMessageIDUsesGeneratedColumn(t *testing.T) {
+	matcher := newQueryRecorder(t)
+	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(matcher))
+	if err != nil {
+		t.Fatalf("create pgx mock: %v", err)
+	}
+	defer mock.Close()
+
+	filter := SpanFilter{
+		OrganizationID: "org-id",
+		MessageID:      "message-id",
+	}
+
+	mock.ExpectQuery("list message spans").
+		WithArgs(filter.OrganizationID, filter.MessageID, 51).
+		WillReturnRows(emptySpanRows())
+
+	_, err = newStoreWithQuerier(mock).ListSpans(context.Background(), filter, 50, nil, OrderByStartTimeDesc)
+	if err != nil {
+		t.Fatalf("list spans: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("expectations: %v", err)
+	}
+
+	query := matcher.queries[0]
+	if !containsAll(query, "message_id = $2") {
+		t.Fatalf("expected message lookup to use generated message_id column, got %s", query)
+	}
+	if containsAll(query, "agyn.thread.message.id") {
+		t.Fatalf("expected message lookup to avoid duplicating generated-column expression, got %s", query)
+	}
+}
+
 func TestListSpansMessageIDTraceScopedKeepsExactTrace(t *testing.T) {
 	matcher := newQueryRecorder(t)
 	mock, err := pgxmock.NewPool(pgxmock.QueryMatcherOption(matcher))

--- a/migrations/0004_message_id_span_attribute.sql
+++ b/migrations/0004_message_id_span_attribute.sql
@@ -1,0 +1,20 @@
+DROP INDEX IF EXISTS idx_spans_message_id;
+
+ALTER TABLE spans
+    DROP COLUMN message_id;
+
+ALTER TABLE spans
+    ADD COLUMN message_id TEXT GENERATED ALWAYS AS (
+        COALESCE(
+            jsonb_path_query_first(
+                COALESCE(resource, '{}'::jsonb),
+                '$.attributes[*] ? (@.key == "agyn.thread.message.id").value.stringValue'
+            ) #>> '{}',
+            jsonb_path_query_first(
+                COALESCE(attributes, '[]'::jsonb),
+                '$[*] ? (@.key == "agyn.thread.message.id").value.stringValue'
+            ) #>> '{}'
+        )
+    ) STORED;
+
+CREATE INDEX idx_spans_message_id ON spans (message_id) WHERE message_id IS NOT NULL;

--- a/test/e2e/spans_test.go
+++ b/test/e2e/spans_test.go
@@ -764,6 +764,7 @@ func TestListSpansFiltering(t *testing.T) {
 func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
 	traceID := newTraceID()
 	transportTraceID := newTraceID()
+	spanMessageTraceID := newTraceID()
 	threadID := fmt.Sprintf("thread-%x", traceID)
 	startNs := uint64(time.Now().UnixNano())
 	orgSpan := buildSpan(
@@ -798,11 +799,20 @@ func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
 		startNs+7_000_000,
 		[]*commonv1.KeyValue{stringAttr("rpc.system", "grpc")},
 	)
+	spanMessageSpan := buildSpan(
+		spanInvocationMessage,
+		spanMessageTraceID,
+		newSpanID(),
+		startNs+8_000_000,
+		startNs+9_000_000,
+		append(invocationMessageAttrs("Span message"), stringAttr(attrMessageID, defaultMessageID)),
+	)
 	resourceSpans := []*tracev1.ResourceSpans{
 		buildResourceSpans([]*tracev1.Span{orgSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, defaultMessageID)),
 		buildResourceSpans([]*tracev1.Span{messageSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, otherMessageID)),
 		buildResourceSpans([]*tracev1.Span{otherOrgSpan}, resourceAttrsWithMessageID(threadID, otherOrganizationID, defaultMessageID)),
 		buildResourceSpans([]*tracev1.Span{transportSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, defaultMessageID)),
+		buildResourceSpans([]*tracev1.Span{spanMessageSpan}, resourceAttrsWithMessageID(threadID, defaultOrganizationID, "")),
 	}
 
 	collectorClient, queryClient := newTracingClients(t)
@@ -828,6 +838,28 @@ func TestListSpansOrganizationAndMessageFilters(t *testing.T) {
 			return
 		}
 		assert.ElementsMatch(c, []string{spanInvocationMessage, spanLLMCall}, spanNames(spans))
+	})
+
+	requireEventually(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+		defer cancel()
+		listResp, err := queryClient.ListSpans(ctx, &tracingv1.ListSpansRequest{
+			OrganizationId: defaultOrganizationID,
+			Filter: &tracingv1.SpanFilter{
+				TraceId:   spanMessageTraceID,
+				MessageId: defaultMessageID,
+			},
+		})
+		assert.NoError(c, err)
+		if err != nil {
+			return
+		}
+		spans := flattenSpans(listResp.GetResourceSpans())
+		if !assert.Len(c, spans, 1) {
+			return
+		}
+		assert.Equal(c, spanInvocationMessage, spans[0].GetName())
+		assert.Equal(c, spanMessageTraceID, spans[0].GetTraceId())
 	})
 
 	requireEventually(t, func(c *assert.CollectT) {


### PR DESCRIPTION
## Summary
- Rebuild the generated `message_id` column so `ListSpans(filter.message_id)` matches `agyn.thread.message.id` on either resource attributes or span attributes.
- Add regression coverage for span-level message IDs while preserving resource-level behavior.

## Context
- Keeps agynio/agents-orchestrator#207 as the cross-repo E2E tracker.
- Addresses agynio/tracing#21 after agynio/agynd-cli#136 began mirroring message IDs onto spans.

## Tests
- `git diff --check`
- `go test ./internal/store ./internal/db ./internal/server ./internal/ingest`
- `go test ./...`
- `go vet ./...`